### PR TITLE
Baseball dedupe fix + weekly cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,12 @@ wheels/
 # Logs
 logs/
 
+# Generated plot artifacts
+plots/*.b64
+
+# Runtime state sidecars
+Scripts/.academic_last_prompted.json
+
 # Jupyter Notebook
 .ipynb_checkpoints
 .virtual_documents/

--- a/Scripts/agent_health.py
+++ b/Scripts/agent_health.py
@@ -1,0 +1,205 @@
+"""Launch Agent health checks for the macOS LaunchAgents under ~/Library/LaunchAgents/com.davidjcox.*.plist.
+
+Three things this module does:
+
+1. `check_all()` — walks every davidjcox.* plist, reports load status and
+   recency of activity (latest mtime among the plist's StandardOut/Error
+   log files).  Returns a list of dicts.
+
+2. `format_summary()` — turns that list into a short human-readable string
+   suitable for a Ntfy push or terminal print.
+
+3. `rebootstrap(label)` — bootout + bootstrap a single agent by its plist
+   path.  Used by the auto-heal logic in run_all.py.
+
+Expected cadences are baked in per agent (we know what we configured).  An
+agent whose latest log mtime exceeds 2x its expected cadence is "stale".
+"""
+
+from __future__ import annotations
+
+import os
+import plistlib
+import subprocess
+import time
+from pathlib import Path
+from typing import Iterable
+
+LAUNCH_AGENTS_DIR = Path.home() / "Library" / "LaunchAgents"
+AGENT_PREFIX = "com.davidjcox."
+
+# Expected interval (seconds) between successful runs, per agent label.
+# Agents missing from this dict use a default of 86400s (1 day).
+# A cadence of None means "run-at-load only, never check staleness".
+EXPECTED_CADENCE: dict[str, int | None] = {
+    "com.davidjcox.spotify-fetch": 3600,            # hourly
+    "com.davidjcox.baseball-entry": 86400,          # daily morning batch
+    "com.davidjcox.daily-food-update": 86400,       # daily food sync
+    "com.davidjcox.laptop-health-summary": 86400,   # daily push
+    "com.davidjcox.project-tracker": 86400,
+    "com.davidjcox.golf-entry": 604800,             # weekly (Mondays 7 AM)
+    "com.davidjcox.ensure-agents": None,            # RunAtLoad-only
+}
+
+STALE_MULTIPLIER = 3  # an agent is "stale" if last log > N × cadence
+
+
+def _gui_uid() -> int:
+    return os.getuid()
+
+
+def _list_loaded_agents() -> set[str]:
+    """Return the set of currently-loaded com.davidjcox.* labels."""
+    try:
+        out = subprocess.run(
+            ["launchctl", "print", f"gui/{_gui_uid()}"],
+            capture_output=True, text=True, timeout=15,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return set()
+    if out.returncode != 0:
+        return set()
+    loaded: set[str] = set()
+    for line in out.stdout.splitlines():
+        # Lines look like '\t\t   31052      0 \tcom.davidjcox.foo' OR
+        # 'com.davidjcox.foo => state' depending on which subsection
+        # launchctl is printing.  Look for the prefix anywhere in the
+        # line, then extract the token starting at the prefix.
+        idx = line.find(AGENT_PREFIX)
+        if idx < 0:
+            continue
+        token = line[idx:].split()[0].rstrip(",")
+        if token.startswith(AGENT_PREFIX):
+            loaded.add(token)
+    return loaded
+
+
+def _read_plist(path: Path) -> dict:
+    try:
+        return plistlib.loads(path.read_bytes()) or {}
+    except Exception:
+        return {}
+
+
+def _latest_log_mtime(plist: dict) -> float | None:
+    """Return the most-recent mtime across StandardOutPath / StandardErrorPath."""
+    paths = []
+    for key in ("StandardOutPath", "StandardErrorPath"):
+        v = plist.get(key)
+        if v:
+            paths.append(Path(v))
+    times = []
+    for p in paths:
+        try:
+            times.append(p.stat().st_mtime)
+        except FileNotFoundError:
+            continue
+    return max(times) if times else None
+
+
+def check_all() -> list[dict]:
+    """Return a list of {label, plist_path, loaded, last_seen_minutes,
+    cadence_minutes, stale} dicts, one per discovered plist."""
+    if not LAUNCH_AGENTS_DIR.exists():
+        return []
+    loaded = _list_loaded_agents()
+    now = time.time()
+    out = []
+    for plist_path in sorted(LAUNCH_AGENTS_DIR.glob(f"{AGENT_PREFIX}*.plist")):
+        plist = _read_plist(plist_path)
+        label = plist.get("Label") or plist_path.stem
+        mtime = _latest_log_mtime(plist)
+        cadence = EXPECTED_CADENCE.get(label, 86400)
+        last_seen_min = ((now - mtime) / 60) if mtime else None
+        # Grace period for freshly-installed plists: if the plist itself was
+        # modified within its cadence window, give it one cadence to fire
+        # before flagging stale.
+        try:
+            plist_age_s = now - plist_path.stat().st_mtime
+        except FileNotFoundError:
+            plist_age_s = float("inf")
+        in_grace = cadence is not None and plist_age_s < cadence
+        if cadence is None:
+            # Run-at-load only — staleness doesn't apply, but a never-loaded
+            # plist (no logs ever) still counts as stale.
+            is_stale = mtime is None
+            cadence_min: float | None = None
+        elif in_grace and mtime is None:
+            is_stale = False
+            cadence_min = cadence / 60
+        else:
+            is_stale = (
+                last_seen_min is None
+                or last_seen_min > (cadence / 60) * STALE_MULTIPLIER
+            )
+            cadence_min = cadence / 60
+        out.append({
+            "label": label,
+            "plist_path": str(plist_path),
+            "loaded": label in loaded,
+            "last_seen_minutes": last_seen_min,
+            "cadence_minutes": cadence_min,
+            "stale": is_stale,
+        })
+    return out
+
+
+def format_summary(checks: Iterable[dict]) -> str:
+    """One-line-per-agent summary suitable for Ntfy."""
+    lines = []
+    for c in checks:
+        if c["last_seen_minutes"] is None:
+            recency = "no logs yet"
+        elif c["last_seen_minutes"] < 60:
+            recency = f"{c['last_seen_minutes']:.0f}m ago"
+        elif c["last_seen_minutes"] < 1440:
+            recency = f"{c['last_seen_minutes']/60:.1f}h ago"
+        else:
+            recency = f"{c['last_seen_minutes']/1440:.1f}d ago"
+        loaded_mark = "[OK]  " if c["loaded"] else "[FAIL]"
+        stale_mark = " [STALE]" if c["stale"] else ""
+        short = c["label"].replace(AGENT_PREFIX, "")
+        lines.append(f"{loaded_mark} {short}: {recency}{stale_mark}")
+    return "\n".join(lines) if lines else "(no davidjcox.* agents found)"
+
+
+def rebootstrap(plist_path: str) -> tuple[bool, str]:
+    """bootout + bootstrap a single agent.  Returns (success, message)."""
+    p = Path(plist_path)
+    if not p.exists():
+        return False, f"plist not found: {plist_path}"
+    label = _read_plist(p).get("Label", p.stem)
+    domain = f"gui/{_gui_uid()}"
+    # bootout: harmless if not loaded (returns non-zero, we ignore).
+    subprocess.run(
+        ["launchctl", "bootout", f"{domain}/{label}"],
+        capture_output=True, text=True, timeout=15,
+    )
+    r = subprocess.run(
+        ["launchctl", "bootstrap", domain, str(p)],
+        capture_output=True, text=True, timeout=15,
+    )
+    if r.returncode == 0:
+        return True, f"rebootstrapped {label}"
+    return False, f"bootstrap {label} failed: {r.stderr.strip() or r.stdout.strip()}"
+
+
+def auto_heal(checks: Iterable[dict]) -> list[str]:
+    """For every stale agent, attempt a rebootstrap.  Returns a list of
+    human-readable messages describing what was done."""
+    msgs = []
+    for c in checks:
+        if c["stale"]:
+            ok, msg = rebootstrap(c["plist_path"])
+            msgs.append(("[OK] " if ok else "[FAIL] ") + msg)
+    return msgs
+
+
+if __name__ == "__main__":
+    import sys
+    checks = check_all()
+    print(format_summary(checks))
+    if "--heal" in sys.argv:
+        print()
+        for m in auto_heal(checks):
+            print(m)

--- a/Scripts/backfill_books.py
+++ b/Scripts/backfill_books.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python
+"""One-time backfill of role + isbn on existing book_content=1 rows.
+
+For each row in publication_stats with book_content=1:
+  1. If row already has both role and isbn -> skip silently.
+  2. Try to derive ISBN automatically:
+       a. From chapter DOI (Springer/Elsevier/Routledge embed parent ISBN).
+       b. From OpenLibrary search by title + author.
+  3. Show row + candidate ISBNs (if any), prompt for role and ISBN.
+
+Roles:
+  author  - David authored this book
+  editor  - David edited this volume
+  chapter - David authored a chapter inside an edited volume
+
+Run from project root:
+    venv/bin/python Scripts/backfill_books.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+from sqlalchemy import create_engine, text
+
+sys.path.insert(0, str(Path(__file__).parent))
+from openlibrary_lookup import lookup_book, isbn_from_chapter_doi  # noqa: E402
+
+load_dotenv()
+engine = create_engine(
+    f"postgresql://{os.getenv('DB_USER')}:{os.getenv('DB_PASSWORD')}"
+    f"@{os.getenv('DB_HOST')}:{os.getenv('DB_PORT')}/{os.getenv('DB_NAME')}"
+)
+
+
+# ---------------------------------------------------------------------------
+# Prompts
+# ---------------------------------------------------------------------------
+def prompt(msg: str, default: str = "") -> str:
+    suffix = f" [{default}]" if default else ""
+    return (input(f"{msg}{suffix}: ").strip() or default)
+
+
+def prompt_choice(msg: str, options: list[str], default_idx: int = 0) -> int:
+    """Prompt user to pick one of `options` by 1-based index.  Returns 0-based idx."""
+    for i, opt in enumerate(options, 1):
+        print(f"    [{i}] {opt}")
+    while True:
+        raw = prompt(msg, str(default_idx + 1))
+        try:
+            n = int(raw) - 1
+            if 0 <= n < len(options):
+                return n
+        except ValueError:
+            pass
+        print("    invalid choice")
+
+
+def prompt_yes_no(msg: str, default: bool = True) -> bool:
+    d = "Y/n" if default else "y/N"
+    while True:
+        raw = input(f"{msg} [{d}]: ").strip().lower()
+        if not raw:
+            return default
+        if raw in ("y", "yes"):
+            return True
+        if raw in ("n", "no"):
+            return False
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+def fetch_book_rows() -> list[dict]:
+    with engine.connect() as conn:
+        rows = conn.execute(text("""
+            SELECT title, year, journal, doi, role, isbn, authors
+            FROM publication_stats
+            WHERE book_content = 1
+            ORDER BY year, title
+        """)).fetchall()
+    return [dict(r._mapping) for r in rows]
+
+
+def update_book_row(title: str, role: str, isbn: str | None) -> None:
+    params = {"role": role, "title": title}
+    set_parts = ["role = :role"]
+    if isbn:
+        params["isbn"] = isbn
+        set_parts.append("isbn = :isbn")
+    sql = f"UPDATE publication_stats SET {', '.join(set_parts)} WHERE title = :title"
+    with engine.begin() as conn:
+        r = conn.execute(text(sql), params)
+        if r.rowcount != 1:
+            raise RuntimeError(
+                f"update_book_row: expected 1 update, got {r.rowcount} for {title!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# ISBN suggestion logic
+# ---------------------------------------------------------------------------
+def suggest_isbns(row: dict) -> list[tuple[str, str]]:
+    """Return [(isbn, source-description), ...] of candidates for this row."""
+    out: list[tuple[str, str]] = []
+
+    # Source 1: chapter DOI
+    if row.get("doi"):
+        from_doi = isbn_from_chapter_doi(row["doi"])
+        if from_doi:
+            out.append((from_doi, f"chapter DOI {row['doi']}"))
+
+    # Source 2: OpenLibrary search (use 'Cox' as author hint since David is
+    # always either author/editor/chapter-author of these rows)
+    try:
+        results = lookup_book(row["title"], "Cox", limit=3)
+    except Exception:
+        results = []
+    for r in results:
+        for isbn in r.get("isbns", []):
+            if isbn not in (i for i, _ in out):
+                year_match = "" if r.get("year") == row.get("year") else f" (yr={r.get('year')}, mismatch)"
+                out.append((isbn, f"OpenLibrary: {r.get('title')!r}{year_match}"))
+        if len(out) >= 6:
+            break
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Main loop
+# ---------------------------------------------------------------------------
+ROLES = ["author", "editor", "chapter", "report"]
+
+
+def process_row(row: dict) -> str:
+    """Returns 'updated' or 'skipped'."""
+    print(f"\n[{row['year']}] {row['title']}")
+    print(f"  journal/publisher: {row.get('journal')}")
+    if row.get("doi"):
+        print(f"  doi:               {row['doi']}")
+    if row.get("authors"):
+        print(f"  authors:           {row['authors']}")
+    print(f"  current role={row.get('role') or '-'}  isbn={row.get('isbn') or '-'}")
+
+    if row.get("role") and row.get("isbn"):
+        print("  already complete -> skipping")
+        return "skipped"
+
+    # Role
+    print("  role:")
+    role_idx = prompt_choice("  pick role", ROLES, default_idx=2)  # default 'chapter'
+    role = ROLES[role_idx]
+
+    # ISBN
+    isbn = row.get("isbn")
+    if not isbn:
+        print("  finding ISBN candidates...")
+        candidates = suggest_isbns(row)
+        if candidates:
+            options = [f"{i}  ({src})" for i, src in candidates] + ["enter manually", "skip ISBN"]
+            print("  candidates:")
+            idx = prompt_choice("  pick ISBN", options, default_idx=0)
+            if idx < len(candidates):
+                isbn = candidates[idx][0]
+            elif idx == len(candidates):  # manual
+                manual = prompt("  ISBN (paste; blank to skip)")
+                isbn = manual or None
+            else:  # skip
+                isbn = None
+        else:
+            print("  no candidates from auto-search")
+            manual = prompt("  ISBN (paste; blank to skip)")
+            isbn = manual or None
+
+    update_book_row(row["title"], role, isbn)
+    print(f"  + role={role}  isbn={isbn or '-'}")
+    return "updated"
+
+
+def main() -> int:
+    rows = fetch_book_rows()
+    print(f"book_content rows in publication_stats: {len(rows)}")
+    counts = {"updated": 0, "skipped": 0}
+    try:
+        for row in rows:
+            counts[process_row(row)] += 1
+    except KeyboardInterrupt:
+        print("\n\n[interrupted]")
+    finally:
+        print("\n=== summary ===")
+        for k, v in counts.items():
+            print(f"  {k}: {v}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Scripts/backfill_publications.py
+++ b/Scripts/backfill_publications.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python
+"""One-time backfill of publication_stats with DOIs and Crossref metadata.
+
+For each PDF in My Articles/:
+  1. Extract DOI (metadata -> text -> OCR fallback).
+  2. If DOI already attached to a publication_stats row -> silent skip.
+  3. If DOI looks up in Crossref:
+        a. If Crossref title (normalized) matches an existing DB row -> ATTACH:
+              prompt 'attach DOI to row X? [Y/n]'.
+        b. Else -> INSERT NEW: prompt with full Crossref metadata for Y/n.
+  4. If DOI extraction fails or Crossref returns nothing:
+        Manual prompt with three options:
+          [1] match to existing DB row (show top 3 fuzzy candidates),
+          [2] insert as new row (you type fields),
+          [3] skip this PDF (will not be re-prompted in future runs because
+              the filename gets added to .academic_ignore.txt).
+
+This script is idempotent: re-running it skips PDFs whose DOIs are already
+in the DB.  Cancelling halfway and restarting is fine.
+
+Usage:
+    python Scripts/backfill_publications.py
+    python Scripts/backfill_publications.py --no-ocr     # skip the slow path
+    python Scripts/backfill_publications.py --limit 5    # first N PDFs only
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Iterable
+
+from dotenv import load_dotenv
+from sqlalchemy import create_engine, text
+
+sys.path.insert(0, str(Path(__file__).parent))
+from doi_extract import extract_doi  # noqa: E402
+from crossref_lookup import lookup_doi_with_retry  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Config / DB
+# ---------------------------------------------------------------------------
+load_dotenv()
+engine = create_engine(
+    f"postgresql://{os.getenv('DB_USER')}:{os.getenv('DB_PASSWORD')}"
+    f"@{os.getenv('DB_HOST')}:{os.getenv('DB_PORT')}/{os.getenv('DB_NAME')}"
+)
+
+ARTICLES_DIR = Path("/Users/davidjcox/Dropbox/Articles/My Articles")
+IGNORE_FILE = Path(__file__).parent / ".academic_ignore.txt"
+
+
+# ---------------------------------------------------------------------------
+# Title normalization (matches update_academic_data.py exactly)
+# ---------------------------------------------------------------------------
+def normalize_title(raw: str) -> str:
+    cleaned = re.sub(r"[^\w\s]", " ", raw or "")
+    return re.sub(r"\s+", " ", cleaned).strip().lower()
+
+
+_ARTICLE_PATTERN = re.compile(r"^\s*(?:\((\d{4})\)\s*)?(.+?)\.pdf$", re.IGNORECASE)
+
+
+def parse_article_filename(name: str) -> tuple[int | None, str]:
+    m = _ARTICLE_PATTERN.match(name)
+    if not m:
+        return None, name
+    year = int(m.group(1)) if m.group(1) else None
+    title = m.group(2).strip()
+    if ", " in title:
+        head, _, tail = title.rpartition(", ")
+        tail_low = tail.lower()
+        if "et al" in tail_low or "&" in tail or re.search(r"\b[A-Z][a-zA-Z\-]+$", tail):
+            title = head
+    return year, title.strip()
+
+
+# ---------------------------------------------------------------------------
+# Prompts
+# ---------------------------------------------------------------------------
+def prompt(msg: str, default: str = "") -> str:
+    suffix = f" [{default}]" if default else ""
+    return (input(f"{msg}{suffix}: ").strip() or default)
+
+
+def prompt_yes_no(msg: str, default: bool = True) -> bool:
+    d = "Y/n" if default else "y/N"
+    while True:
+        raw = input(f"{msg} [{d}]: ").strip().lower()
+        if not raw:
+            return default
+        if raw in ("y", "yes"):
+            return True
+        if raw in ("n", "no"):
+            return False
+
+
+def prompt_int(msg: str, default: int | None = None) -> int:
+    while True:
+        raw = prompt(msg, str(default) if default is not None else "")
+        try:
+            return int(raw)
+        except ValueError:
+            print("  must be an integer")
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+def load_db_state() -> tuple[dict[str, dict], set[str]]:
+    """Return (rows-by-normalized-title, set-of-DOIs-already-attached)."""
+    by_title: dict[str, dict] = {}
+    dois: set[str] = set()
+    with engine.connect() as conn:
+        for r in conn.execute(text("SELECT * FROM publication_stats")).fetchall():
+            d = dict(r._mapping)
+            if d.get("title"):
+                by_title[normalize_title(d["title"])] = d
+            if d.get("doi"):
+                dois.add(d["doi"].lower())
+    return by_title, dois
+
+
+def attach_doi(title: str, doi: str, crossref: dict) -> None:
+    """Attach DOI + Crossref metadata to an existing row, identified by exact
+    title match.  Overwrites journal/year/authors with Crossref's values
+    (per the design: 'overwrite with canonical title' implies trusting the
+    rest too)."""
+    updates = {"doi": doi}
+    if crossref.get("title"):
+        updates["title_new"] = crossref["title"]  # rename in place
+    if crossref.get("journal"):
+        updates["journal"] = crossref["journal"]
+    if crossref.get("year"):
+        updates["year"] = crossref["year"]
+    if crossref.get("authors"):
+        updates["authors"] = crossref["authors"]
+
+    set_parts = []
+    params = {"title_match": title}
+    for k, v in updates.items():
+        if k == "title_new":
+            set_parts.append("title = :title_new")
+            params["title_new"] = v
+        else:
+            set_parts.append(f"{k} = :{k}")
+            params[k] = v
+
+    sql = f"UPDATE publication_stats SET {', '.join(set_parts)} WHERE title = :title_match"
+    with engine.begin() as conn:
+        r = conn.execute(text(sql), params)
+        if r.rowcount != 1:
+            raise RuntimeError(f"attach_doi: expected 1 update, got {r.rowcount} for title {title!r}")
+
+
+def insert_new(crossref: dict, doi: str | None, role: str,
+               theoretical: int = 0, empirical: int = 0,
+               commentary: int = 0, book_content: int = 0) -> None:
+    row = {
+        "year": crossref.get("year"),
+        "title": crossref.get("title"),
+        "journal": crossref.get("journal"),
+        "authors": crossref.get("authors"),
+        "doi": doi,
+        "isbn": None,
+        "role": role,
+        "new_journal": "No",
+        "number_words": 0,
+        "number_pages": 0,
+        "number_journals": 0,
+        "theoretical_articles": theoretical,
+        "empirical_articles": empirical,
+        "commentary_replies": commentary,
+        "book_content": book_content,
+    }
+    cols = ", ".join(row.keys())
+    placeholders = ", ".join(f":{k}" for k in row.keys())
+    with engine.begin() as conn:
+        conn.execute(text(f"INSERT INTO publication_stats ({cols}) VALUES ({placeholders})"), row)
+
+
+# ---------------------------------------------------------------------------
+# Per-PDF flows
+# ---------------------------------------------------------------------------
+ARTICLE_TYPE_CHOICES = """
+  article type:
+    1) theoretical
+    2) empirical
+    3) commentary / reply
+    4) book content (for book chapters)
+""".strip()
+
+
+def ask_article_type() -> dict[str, int]:
+    print(ARTICLE_TYPE_CHOICES)
+    while True:
+        c = prompt("  choice (1-4)", "2")
+        if c in {"1", "2", "3", "4"}:
+            break
+    return {
+        "theoretical": 1 if c == "1" else 0,
+        "empirical":   1 if c == "2" else 0,
+        "commentary":  1 if c == "3" else 0,
+        "book_content": 1 if c == "4" else 0,
+    }
+
+
+def show_crossref(crossref: dict) -> None:
+    print(f"    title:    {crossref.get('title')}")
+    print(f"    journal:  {crossref.get('journal')}")
+    print(f"    year:     {crossref.get('year')}")
+    print(f"    authors:  {crossref.get('authors')}")
+    print(f"    type:     {crossref.get('type')}")
+
+
+def role_from_crossref_type(t: str | None) -> str:
+    return {
+        "journal-article": "article",
+        "book-chapter": "chapter",
+        "book": "author",
+        "monograph": "author",
+        "edited-book": "editor",
+        "posted-content": "preprint",
+        "report": "report",
+    }.get(t or "", "article")
+
+
+def article_type_from_crossref(t: str | None) -> dict[str, int]:
+    if t == "book-chapter":
+        return {"theoretical": 0, "empirical": 0, "commentary": 0, "book_content": 1}
+    return {"theoretical": 0, "empirical": 1, "commentary": 0, "book_content": 0}
+
+
+def fuzzy_title_candidates(file_title: str, by_title: dict[str, dict],
+                           top: int = 3) -> list[dict]:
+    """Cheap candidate ranking: count shared word-runs of length 3+ between
+    the file title and each DB title."""
+    fn = normalize_title(file_title).split()
+    scored = []
+    for db_norm, row in by_title.items():
+        db_words = db_norm.split()
+        # count word overlap (Jaccard-ish)
+        shared = len(set(fn) & set(db_words))
+        if shared < 3:
+            continue
+        scored.append((shared, row))
+    scored.sort(key=lambda x: -x[0])
+    return [r for _, r in scored[:top]]
+
+
+def add_to_ignore(filename: str) -> None:
+    line = filename.replace(".pdf", "").lstrip("()0123456789 ")
+    with IGNORE_FILE.open("a") as f:
+        f.write(f"\n# Skipped during backfill {Path(__file__).name}\n{line}\n")
+
+
+def process_pdf(pdf: Path, by_title: dict[str, dict], dois: set[str],
+                allow_ocr: bool) -> str:
+    """Returns one of: 'attached', 'inserted', 'skipped', 'already-known'."""
+    file_year, file_title = parse_article_filename(pdf.name)
+    print(f"\n[{pdf.name}]")
+
+    # Step 1: extract DOI
+    doi, src = extract_doi(pdf, allow_ocr=allow_ocr)
+    if doi:
+        print(f"  DOI: {doi} (via {src})")
+        if doi in dois:
+            print("  already in DB -> skipping")
+            return "already-known"
+    else:
+        print(f"  DOI: <not found>")
+
+    # Step 2: Crossref lookup if we have a DOI
+    crossref = lookup_doi_with_retry(doi) if doi else None
+    if crossref:
+        print("  Crossref:")
+        show_crossref(crossref)
+        # Try to match an existing DB row using EITHER the file-derived title
+        # OR the Crossref canonical title.  This catches the common case
+        # where the DB's title is a renamed-from-filename shorthand and the
+        # Crossref title is the formal version (or vice versa).
+        file_norm = normalize_title(file_title)
+        canon_norm = normalize_title(crossref.get("title") or "")
+        match = by_title.get(file_norm) or by_title.get(canon_norm)
+        old_norm = file_norm if file_norm in by_title else canon_norm
+        if match:
+            print(f"  -> matches existing row: {match['title']!r}")
+            if prompt_yes_no("  attach DOI and update with Crossref values?", True):
+                attach_doi(match["title"], doi, crossref)
+                # Refresh in-memory state under the new canonical title
+                new_norm = normalize_title(crossref["title"])
+                by_title.pop(old_norm, None)
+                fresh = dict(match)
+                fresh["title"] = crossref["title"]
+                fresh["doi"] = doi
+                by_title[new_norm] = fresh
+                dois.add(doi)
+                return "attached"
+            return "skipped"
+        # No exact match — insert new
+        if prompt_yes_no("  insert as new publication_stats row?", True):
+            role = role_from_crossref_type(crossref.get("type"))
+            type_flags = article_type_from_crossref(crossref.get("type"))
+            insert_new(crossref, doi, role, **type_flags)
+            by_title[canon_norm] = {
+                "title": crossref["title"], "doi": doi, "year": crossref.get("year"),
+                "journal": crossref.get("journal"), "authors": crossref.get("authors"),
+            }
+            dois.add(doi)
+            return "inserted"
+        return "skipped"
+
+    # Step 3: manual fallback (no DOI or Crossref miss)
+    candidates = fuzzy_title_candidates(file_title, by_title)
+    print(f"  filename title: {file_title!r}")
+    if candidates:
+        print("  closest existing rows:")
+        for i, c in enumerate(candidates, 1):
+            print(f"    [{i}] ({c.get('year')}) {c.get('title')}  | {c.get('journal')}")
+    print("  options:")
+    print("    [1-3] match to candidate above")
+    print("    [n]   insert as new (manual entry)")
+    print("    [s]   skip this PDF and add filename to ignore list")
+    while True:
+        choice = prompt("  choice", "s").lower()
+        if choice == "s":
+            add_to_ignore(pdf.name)
+            return "skipped"
+        if choice == "n":
+            year = file_year or prompt_int("  year", file_year or 2026)
+            title = prompt("  title", file_title)
+            journal = prompt("  journal")
+            authors = prompt("  authors (optional)")
+            type_flags = ask_article_type()
+            crossref_like = {
+                "year": year, "title": title, "journal": journal, "authors": authors,
+                "type": None,
+            }
+            insert_new(crossref_like, doi, "article", **type_flags)
+            by_title[normalize_title(title)] = {
+                "title": title, "doi": doi, "year": year, "journal": journal,
+            }
+            if doi:
+                dois.add(doi)
+            return "inserted"
+        if choice in ("1", "2", "3"):
+            idx = int(choice) - 1
+            if idx >= len(candidates):
+                print("  no such candidate")
+                continue
+            match = candidates[idx]
+            # Attach DOI (no Crossref values to overwrite with)
+            if doi:
+                with engine.begin() as conn:
+                    conn.execute(
+                        text("UPDATE publication_stats SET doi = :d WHERE title = :t"),
+                        {"d": doi, "t": match["title"]},
+                    )
+                dois.add(doi)
+                print(f"  attached DOI to existing row")
+                return "attached"
+            else:
+                print(f"  no DOI to attach; nothing to do")
+                return "already-known"
+        print("  unrecognized choice")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--no-ocr", action="store_true",
+                    help="Skip OCR fallback (faster but misses some DOIs)")
+    ap.add_argument("--limit", type=int, default=None,
+                    help="Process only the first N PDFs (for testing)")
+    args = ap.parse_args()
+
+    if not ARTICLES_DIR.exists():
+        print(f"ERROR: {ARTICLES_DIR} not found")
+        return 1
+
+    by_title, dois = load_db_state()
+    print(f"DB starting state: {len(by_title)} rows, {len(dois)} with DOIs")
+
+    pdfs: Iterable[Path] = sorted(ARTICLES_DIR.glob("*.pdf"))
+    if args.limit:
+        pdfs = list(pdfs)[: args.limit]
+    pdfs = list(pdfs)
+    print(f"Scanning {len(pdfs)} PDFs (OCR {'OFF' if args.no_ocr else 'ON'})\n")
+
+    counts = {"attached": 0, "inserted": 0, "skipped": 0, "already-known": 0}
+    try:
+        for pdf in pdfs:
+            result = process_pdf(pdf, by_title, dois, allow_ocr=not args.no_ocr)
+            counts[result] += 1
+    except KeyboardInterrupt:
+        print("\n\n[interrupted by user]")
+    finally:
+        print("\n=== summary ===")
+        for k, v in counts.items():
+            print(f"  {k}: {v}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Scripts/baseball_entry.py
+++ b/Scripts/baseball_entry.py
@@ -12,6 +12,8 @@ import requests
 from dotenv import load_dotenv
 from flask import Flask, request
 from sqlalchemy import create_engine, text
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy import MetaData, Table
 
 # ---------------------------------------------------------------------------
 # Config
@@ -26,8 +28,13 @@ DB_PORT = os.getenv("DB_PORT")
 
 DATABASE_URL = f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
 engine = create_engine(DATABASE_URL)
+_baseball_table = Table("baseball_watched_long", MetaData(), autoload_with=engine)
 
 PORT = 8052
+
+# Re-entry guards for /submit and /no-games
+_submit_lock = threading.Lock()
+_submitted = False
 
 # Allow date override via --date YYYY-MM-DD for backfilling missed days
 _date_override = None
@@ -252,7 +259,11 @@ def index():
         <div class="card">
           <h2>MLB Games &mdash; {date_str}</h2>
           <p class="msg">No games were played on this date.</p>
-          <form method="post" action="/no-games">
+          <form method="post" action="/no-games" onsubmit="
+            if (this.dataset.submitted) return false;
+            this.dataset.submitted = '1';
+            for (const b of this.querySelectorAll('button')) {{ b.disabled = true; }}
+          ">
             <button class="btn btn-secondary" type="submit">Close</button>
           </form>
         </div>"""
@@ -279,7 +290,11 @@ def index():
     <div class="card">
       <h2>MLB Games &mdash; {date_str}</h2>
       {warning}
-      <form method="post" action="/submit">
+      <form method="post" action="/submit" onsubmit="
+        if (this.dataset.submitted) return false;
+        this.dataset.submitted = '1';
+        for (const b of this.querySelectorAll('button')) {{ b.disabled = true; }}
+      ">
         {rows}
         <hr style="margin:16px 0">
         <button class="btn btn-primary" type="submit">Submit</button>
@@ -294,6 +309,13 @@ def index():
 
 @app.route("/submit", methods=["POST"])
 def submit():
+    global _submitted
+    with _submit_lock:
+        if _submitted:
+            recent = recent_entries_html()
+            return page("MLB Games", f'<div class="card"><p class="msg">Already submitted. You can close this tab.</p>{recent}</div>')
+        _submitted = True
+
     games = app.config.get("GAMES", [])
     selected = request.form.getlist("game")
 
@@ -318,7 +340,13 @@ def submit():
             "in_person": in_person,
         })
 
-    pd.DataFrame(rows).to_sql("baseball_watched_long", engine, if_exists="append", index=False)
+    # ON CONFLICT DO NOTHING — relies on unique index (date, box_score)
+    with engine.begin() as conn:
+        conn.execute(
+            pg_insert(_baseball_table)
+            .values(rows)
+            .on_conflict_do_nothing(index_elements=["date", "box_score"])
+        )
 
     count = len(rows)
     recent = recent_entries_html()
@@ -330,6 +358,13 @@ def submit():
 
 @app.route("/no-games", methods=["POST"])
 def no_games():
+    global _submitted
+    with _submit_lock:
+        if _submitted:
+            recent = recent_entries_html()
+            return page("MLB Games", f'<div class="card"><p class="msg">Already submitted. You can close this tab.</p>{recent}</div>')
+        _submitted = True
+
     recent = recent_entries_html()
     body = f'<div class="card"><p class="msg">No entries recorded. You can close this tab.</p>{recent}</div>'
     mark_ran_today()

--- a/Scripts/crossref_lookup.py
+++ b/Scripts/crossref_lookup.py
@@ -1,0 +1,104 @@
+"""Crossref metadata lookup by DOI.
+
+Crossref's REST API at api.crossref.org is free, no auth required.  Their
+docs ask for a User-Agent string with contact info so they can reach you if
+your traffic looks abusive.
+
+Usage:
+    info = lookup_doi('10.1002/jaba.381')
+    # -> {'title': 'Application of the matching law...',
+    #     'journal': 'Journal of Applied Behavior Analysis',
+    #     'year': 2017,
+    #     'authors': 'Cox, Sosine, Dallery'}
+"""
+
+from __future__ import annotations
+
+import time
+
+import requests
+
+USER_AGENT = "quantified-self-app/1.0 (mailto:cox.david.j@gmail.com)"
+BASE_URL = "https://api.crossref.org/works/"
+TIMEOUT = 15
+
+
+def _author_string(authors: list[dict]) -> str:
+    """Join authors into 'Cox, Sosine, Dallery' style.  Crossref returns one
+    dict per author with 'given' + 'family' (sometimes only 'name')."""
+    out = []
+    for a in authors:
+        family = a.get("family") or a.get("name") or ""
+        if family:
+            out.append(family)
+    return ", ".join(out)
+
+
+def _year_from(message: dict) -> int | None:
+    """Crossref publication year hides in several places.  Try in order."""
+    for key in ("published-print", "published-online", "issued", "created"):
+        d = message.get(key, {})
+        parts = d.get("date-parts") or []
+        if parts and parts[0]:
+            return int(parts[0][0])
+    return None
+
+
+def lookup_doi(doi: str) -> dict | None:
+    """Return canonical metadata for a DOI, or None on miss/error."""
+    url = BASE_URL + doi
+    try:
+        r = requests.get(url, headers={"User-Agent": USER_AGENT}, timeout=TIMEOUT)
+    except requests.RequestException:
+        return None
+    if r.status_code != 200:
+        return None
+    try:
+        msg = r.json().get("message") or {}
+    except ValueError:
+        return None
+
+    # Title is a list of strings; subtitle is a separate list.  Concatenate
+    # cleanly so 'Foo: Bar' style citations come out right.
+    titles = msg.get("title") or []
+    subtitles = msg.get("subtitle") or []
+    title = (titles[0] if titles else "").strip()
+    if subtitles and subtitles[0].strip():
+        sep = ": " if not title.endswith((":", "?", "!")) else " "
+        title = f"{title}{sep}{subtitles[0].strip()}"
+
+    # Container ('container-title') is journal/book name.
+    containers = msg.get("container-title") or []
+    journal = (containers[0] if containers else "").strip()
+
+    return {
+        "title": title or None,
+        "journal": journal or None,
+        "year": _year_from(msg),
+        "authors": _author_string(msg.get("author") or []) or None,
+        "type": msg.get("type"),  # 'journal-article', 'book-chapter', 'book', etc.
+        "publisher": (msg.get("publisher") or "").strip() or None,
+    }
+
+
+def lookup_doi_with_retry(doi: str, retries: int = 2, backoff: float = 1.5) -> dict | None:
+    """Crossref occasionally rate-limits or has transient 5xx responses.
+    Retry once with exponential backoff before giving up."""
+    for attempt in range(retries + 1):
+        result = lookup_doi(doi)
+        if result is not None:
+            return result
+        if attempt < retries:
+            time.sleep(backoff * (2 ** attempt))
+    return None
+
+
+if __name__ == "__main__":
+    import sys
+    import json
+    if len(sys.argv) < 2:
+        print("usage: python crossref_lookup.py <doi> [<doi> ...]")
+        sys.exit(1)
+    for d in sys.argv[1:]:
+        info = lookup_doi_with_retry(d)
+        print(f"{d}: {json.dumps(info, indent=2) if info else '<not found>'}")

--- a/Scripts/doi_extract.py
+++ b/Scripts/doi_extract.py
@@ -1,0 +1,111 @@
+"""DOI extraction from PDFs.
+
+Tries three layers, in order, returning as soon as one succeeds:
+  1. PDF metadata fields (subject, doi, identifier).
+  2. Regex over text extracted from the first 3 pages.
+  3. OCR of the first 2 pages (fallback for scanned PDFs).
+
+Returns the DOI as a lowercased string with no surrounding punctuation, or
+None if nothing matches.
+
+The DOI regex follows Crossref's recommended pattern:
+    10.\\d{4,9}/[-._;()/:A-Z0-9]+
+We additionally trim trailing punctuation that often gets pulled in from
+running text (".", ",", ")") since the DOI grammar excludes them at end-of-token.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pdfplumber
+import pypdf
+
+DOI_REGEX = re.compile(r"\b(10\.\d{4,9}/[-._;()/:A-Z0-9]+)", re.IGNORECASE)
+TRAILING_PUNCT = re.compile(r"[.,;)\]>]+$")
+
+
+def _clean(doi: str) -> str:
+    return TRAILING_PUNCT.sub("", doi).lower().strip()
+
+
+def _from_metadata(path: Path) -> str | None:
+    try:
+        reader = pypdf.PdfReader(str(path))
+        meta = reader.metadata or {}
+    except Exception:
+        return None
+    for key in ("/doi", "/DOI", "/Subject", "/Title", "/Identifier", "/prism:doi"):
+        val = meta.get(key)
+        if not val:
+            continue
+        m = DOI_REGEX.search(str(val))
+        if m:
+            return _clean(m.group(1))
+    return None
+
+
+def _from_text(path: Path, max_pages: int = 3) -> str | None:
+    try:
+        with pdfplumber.open(str(path)) as pdf:
+            for page in pdf.pages[:max_pages]:
+                txt = page.extract_text() or ""
+                m = DOI_REGEX.search(txt)
+                if m:
+                    return _clean(m.group(1))
+    except Exception:
+        return None
+    return None
+
+
+def _from_ocr(path: Path, max_pages: int = 2) -> str | None:
+    """OCR the first few pages — slow, only invoke when the cheaper layers
+    have already failed."""
+    try:
+        from PIL import Image
+        import pytesseract
+        import pypdfium2 as pdfium
+    except ImportError:
+        return None
+    try:
+        doc = pdfium.PdfDocument(str(path))
+    except Exception:
+        return None
+    try:
+        for i in range(min(max_pages, len(doc))):
+            page = doc[i]
+            pil_image = page.render(scale=2.0).to_pil()
+            txt = pytesseract.image_to_string(pil_image)
+            m = DOI_REGEX.search(txt)
+            if m:
+                return _clean(m.group(1))
+    finally:
+        doc.close()
+    return None
+
+
+def extract_doi(path: Path, allow_ocr: bool = True) -> tuple[str | None, str]:
+    """Return (doi, source) where source is 'metadata' / 'text' / 'ocr' / 'none'."""
+    doi = _from_metadata(path)
+    if doi:
+        return doi, "metadata"
+    doi = _from_text(path)
+    if doi:
+        return doi, "text"
+    if allow_ocr:
+        doi = _from_ocr(path)
+        if doi:
+            return doi, "ocr"
+    return None, "none"
+
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) < 2:
+        print("usage: python doi_extract.py <pdf-path> [<pdf-path> ...]")
+        sys.exit(1)
+    for arg in sys.argv[1:]:
+        p = Path(arg)
+        doi, src = extract_doi(p, allow_ocr=True)
+        print(f"{p.name}: {doi or '<not found>'} ({src})")

--- a/Scripts/laptop_health_summary.py
+++ b/Scripts/laptop_health_summary.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+"""Daily Ntfy push summarizing Launch Agent health.
+
+Run by ~/Library/LaunchAgents/com.davidjcox.laptop-health-summary.plist
+once per day.  Sends a short summary of each davidjcox.* agent's recent
+activity.  Stale agents trigger a louder alert (priority=high + tag).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from agent_health import check_all, format_summary  # noqa: E402
+from ntfy import push  # noqa: E402
+
+
+def main() -> int:
+    checks = check_all()
+    summary = format_summary(checks)
+    stale_agents = [c for c in checks if c["stale"]]
+    if stale_agents:
+        title = f"Laptop health: {len(stale_agents)} agent(s) STALE"
+        priority = "high"
+    else:
+        title = "Laptop health OK"
+        priority = "low"
+    push(summary, title=title, priority=priority)
+    print(f"[{title}]\n{summary}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Scripts/ntfy.py
+++ b/Scripts/ntfy.py
@@ -1,0 +1,45 @@
+"""Minimal Ntfy push helper.  Reads NTFY_TOPIC from .env / env."""
+
+from __future__ import annotations
+
+import os
+
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+NTFY_URL = "https://ntfy.sh"
+TOPIC = os.getenv("NTFY_TOPIC")
+
+
+def push(message: str, title: str | None = None,
+         priority: str | None = None, tags: list[str] | None = None) -> bool:
+    """Send a push.  Returns True on HTTP 2xx, False otherwise (silent fail
+    is fine — we don't want a missed notification to crash run_all)."""
+    if not TOPIC:
+        return False
+    headers = {}
+    if title:
+        headers["Title"] = title
+    if priority:
+        headers["Priority"] = priority
+    if tags:
+        headers["Tags"] = ",".join(tags)
+    try:
+        r = requests.post(
+            f"{NTFY_URL}/{TOPIC}",
+            data=message.encode("utf-8"),
+            headers=headers,
+            timeout=10,
+        )
+        return r.status_code // 100 == 2
+    except requests.RequestException:
+        return False
+
+
+if __name__ == "__main__":
+    import sys
+    msg = " ".join(sys.argv[1:]) or "test from quantified-self-app"
+    ok = push(msg, title="agent_health test")
+    print(f"sent: {ok}")

--- a/Scripts/openlibrary_lookup.py
+++ b/Scripts/openlibrary_lookup.py
@@ -1,0 +1,89 @@
+"""OpenLibrary book search by title + author.
+
+OpenLibrary's REST API (openlibrary.org/search.json) is free, no auth.
+Returns all known ISBNs for a work, which the caller is expected to
+disambiguate (different editions/formats share a work but have separate
+ISBNs).
+
+Usage:
+    candidates = lookup_book('Research Ethics in Behavior Analysis', 'Cox')
+    # -> [{'title': '...', 'year': 2022, 'isbns': [...], 'key': '...'}]
+"""
+
+from __future__ import annotations
+
+import requests
+
+USER_AGENT = "quantified-self-app/1.0 (mailto:cox.david.j@gmail.com)"
+BASE_URL = "https://openlibrary.org/search.json"
+TIMEOUT = 15
+
+
+def lookup_book(title: str, author: str | None = None,
+                limit: int = 5) -> list[dict]:
+    """Search OpenLibrary by title (and optional author).  Returns up to
+    `limit` work records, each with all known ISBNs."""
+    params = {
+        "title": title,
+        "fields": "title,first_publish_year,isbn,key,author_name",
+        "limit": limit,
+    }
+    if author:
+        params["author"] = author
+    try:
+        r = requests.get(BASE_URL, params=params,
+                         headers={"User-Agent": USER_AGENT}, timeout=TIMEOUT)
+    except requests.RequestException:
+        return []
+    if r.status_code != 200:
+        return []
+    try:
+        docs = r.json().get("docs") or []
+    except ValueError:
+        return []
+
+    out = []
+    for d in docs:
+        isbns = d.get("isbn") or []
+        # Keep ISBN-13s only — ISBN-10s are the same book, just legacy format.
+        isbn13s = [i for i in isbns if len(i) == 13]
+        out.append({
+            "title": d.get("title"),
+            "year": d.get("first_publish_year"),
+            "isbns": isbn13s or isbns,  # fall back to ISBN-10 if no 13
+            "key": d.get("key"),
+            "authors": d.get("author_name") or [],
+        })
+    return out
+
+
+def isbn_from_chapter_doi(doi: str) -> str | None:
+    """Several publishers embed the parent book's ISBN in chapter DOIs:
+        Springer:    10.1007/978-3-030-96478-8_4    -> 9783030964788
+        Elsevier:    10.1016/b978-0-323-99594-8.00009-x -> 9780323995948
+        Routledge:   10.4324/9781003380603-7        -> 9781003380603
+    Returns ISBN-13 (digits only) or None if no pattern matches.
+    """
+    import re
+    if not doi:
+        return None
+    # ISBN-13 starts with 978, has 13 digits total.  Publishers embed it
+    # in DOIs in different ways: hyphenated (Springer 978-3-030-96478-8),
+    # half-hyphenated (Elsevier b978-0-323-99594-8), or unhyphenated
+    # (Routledge 9781003380603).  Strip non-digits, then look for any
+    # 13-digit run starting with 978.
+    digits_only = re.sub(r"[^\d]", "", doi)
+    m = re.search(r"(978\d{10})", digits_only)
+    return m.group(1) if m else None
+
+
+if __name__ == "__main__":
+    import sys
+    import json
+    if len(sys.argv) < 2:
+        print("usage: python openlibrary_lookup.py 'title' [author]")
+        sys.exit(1)
+    title = sys.argv[1]
+    author = sys.argv[2] if len(sys.argv) > 2 else None
+    results = lookup_book(title, author)
+    print(json.dumps(results, indent=2))

--- a/Scripts/run_all.py
+++ b/Scripts/run_all.py
@@ -158,6 +158,32 @@ except subprocess.CalledProcessError as e:
 except Exception as e:
     print(f"An unexpected error occurred prepping data for unsupervised learning: {e}")
 
+# Launch Agent health check + auto-heal.  Re-bootstraps any davidjcox.*
+# agent whose log mtime exceeds 3x its expected cadence.  Pushes Ntfy on
+# any healing action so the user knows what was fixed without needing to
+# check logs.
+print("\n\nChecking Launch Agent health...")
+try:
+    import sys as _sys
+    _sys.path.insert(0, str(Path(__file__).parent))
+    from agent_health import check_all, format_summary, auto_heal
+    from ntfy import push as _ntfy_push
+    _checks = check_all()
+    print(format_summary(_checks))
+    _stale = [c for c in _checks if c["stale"]]
+    if _stale:
+        _msgs = auto_heal(_checks)
+        print("\nauto-heal:")
+        for m in _msgs:
+            print(f"  {m}")
+        _ntfy_push(
+            "\n".join(_msgs),
+            title=f"Healed {len(_stale)} stale Launch Agent(s)",
+            priority="default",
+        )
+except Exception as e:
+    print(f"Error during Launch Agent health check: {e}")
+
 # Run the dashboard script
 print("\n\nRunning dashboard creation...")
 run_script('app.py')

--- a/Scripts/spotify_weekly_data.py
+++ b/Scripts/spotify_weekly_data.py
@@ -243,7 +243,10 @@ def convert_spotify_to_extended_format(items):
         track = item['track']
         played_at = item['played_at']
         
-        # Convert to Extended Streaming History format
+        # The API doesn't return actual play time. Use Spotify's 30-second
+        # play-count threshold as a conservative estimate; Extended Streaming
+        # History exports will overwrite these with true ms_played later.
+        API_MS_PLAYED_ESTIMATE = 30_000
         converted_item = {
             'ts': played_at,
             'date': pd.to_datetime(played_at).date().isoformat(),
@@ -251,9 +254,9 @@ def convert_spotify_to_extended_format(items):
             'master_metadata_track_name': track['name'],
             'master_metadata_album_artist_name': track['artists'][0]['name'] if track['artists'] else None,
             'master_metadata_album_album_name': track['album']['name'],
-            'ms_played': track.get('duration_ms', 0),  # Full duration - API doesn't provide actual play time
-            'seconds_played': track.get('duration_ms', 0) / 1000 if track.get('duration_ms') else 0,
-            'minutes_played': track.get('duration_ms', 0) / 60000 if track.get('duration_ms') else 0,
+            'ms_played': API_MS_PLAYED_ESTIMATE,
+            'seconds_played': API_MS_PLAYED_ESTIMATE / 1000,
+            'minutes_played': API_MS_PLAYED_ESTIMATE / 60000,
             'platform': 'api',  # Mark as API source
             'conn_country': None,  # Not available in API
             'spotify_track_uri': track['uri'],

--- a/Scripts/update_academic_data.py
+++ b/Scripts/update_academic_data.py
@@ -32,10 +32,8 @@ DATABASE_URL = f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NA
 engine = create_engine(DATABASE_URL)
 
 CV_PATH = Path("/Users/davidjcox/Dropbox/Curriculum Vitae/2026/David J. Cox CV.docx")
-PROJECTS_ROOT = Path("/Users/davidjcox/Dropbox/Projects")
-UNDER_REVIEW_DIR = PROJECTS_ROOT / "Manuscripts Under Review"
-PUBLISHED_DIR = PROJECTS_ROOT / "Manuscripts With Decisions" / "Published"
-REJECTED_DIR = PROJECTS_ROOT / "Manuscripts With Decisions" / "Rejected"
+ARTICLES_DIR = Path("/Users/davidjcox/Dropbox/Articles/My Articles")
+BOOKS_DIR = Path("/Users/davidjcox/Dropbox/Articles/My Books")
 
 # Sidecar for once-per-season prompts (peer_reviewer is once-per-run).
 STATE_FILE = Path(__file__).parent / ".academic_last_prompted.json"
@@ -262,210 +260,83 @@ def popular_media_totals(sections: dict) -> dict[str, int]:
 
 
 # ---------------------------------------------------------------------------
-# Manuscript scanning
+# Article / book scanning
 # ---------------------------------------------------------------------------
 def normalize_title(raw: str) -> str:
-    """Lowercase, strip punctuation/whitespace for title matching."""
-    return re.sub(r"[^\w\s]", "", raw).strip().lower()
+    """Lowercase, strip punctuation, collapse whitespace for title matching."""
+    cleaned = re.sub(r"[^\w\s]", " ", raw)
+    return re.sub(r"\s+", " ", cleaned).strip().lower()
 
 
-def find_main_docx(folder: Path) -> Path | None:
-    """Pick the likely manuscript .docx inside a manuscript folder.
+# Filename pattern: '(YYYY) Title, Authors.pdf'.  Year is optional so we can
+# also process files that lack the prefix.
+_ARTICLE_PATTERN = re.compile(r"^\s*(?:\((\d{4})\)\s*)?(.+?)\.pdf$", re.IGNORECASE)
 
-    Preference order:
-      1. 'Manuscript.docx'
-      2. 'Main Manuscript*.docx' (prefers 'With Title' over 'No Title')
-      3. file name matching folder name (ignoring parenthetical prefixes)
-      4. any .docx that is NOT cover letter / title page / figures / tables
-         / appendix / preprint / response
-      5. one level of recursion into subfolders, same rules
+
+def parse_article_filename(name: str) -> tuple[int | None, str]:
+    """Pull (year, title-without-author-tail) from a 'My Articles' filename.
+
+    Filenames look like:
+      '(2017) Application of the matching law to pitch selection..., Cox et al..pdf'
+    Title is everything after the year, with the trailing ', Author...'
+    chunk stripped so the title alone is used for dedup and CV lookup.
     """
-    def search(dir_: Path) -> Path | None:
-        docxs = [
-            p for p in dir_.glob("*.docx")
-            if not p.name.startswith("~$") and p.stat().st_size > 0
-        ]
-        if not docxs:
-            return None
+    m = _ARTICLE_PATTERN.match(name)
+    if not m:
+        return None, name
+    year = int(m.group(1)) if m.group(1) else None
+    title_with_authors = m.group(2).strip()
 
-        for p in docxs:
-            if p.stem.lower() == "manuscript":
-                return p
-
-        main_manuscripts = [p for p in docxs if p.stem.lower().startswith("main manuscript")]
-        if main_manuscripts:
-            with_title = [p for p in main_manuscripts if "with title" in p.stem.lower()]
-            if with_title:
-                return with_title[0]
-            return main_manuscripts[0]
-
-        folder_norm = normalize_title(dir_.name)
-        for p in docxs:
-            if normalize_title(p.stem) == folder_norm:
-                return p
-
-        excluded = (
-            "cover letter", "title page", "figures", "tables", "appendix",
-            "preprint", "response", "revision notes", "reply",
-        )
-        candidates = [p for p in docxs if not any(x in p.stem.lower() for x in excluded)]
-        if len(candidates) == 1:
-            return candidates[0]
-        if len(candidates) > 1:
-            candidates.sort(key=lambda p: p.stat().st_mtime, reverse=True)
-            return candidates[0]
-        return None
-
-    hit = search(folder)
-    if hit:
-        return hit
-    for sub in folder.iterdir():
-        if sub.is_dir() and not sub.name.startswith("."):
-            hit = search(sub)
-            if hit:
-                return hit
-    return None
+    # Strip trailing author chunk: split on the last ', ' and drop it if the
+    # tail looks like an author list (contains a known marker).  Otherwise
+    # keep the whole title.
+    if ", " in title_with_authors:
+        head, _, tail = title_with_authors.rpartition(", ")
+        tail_low = tail.lower()
+        if (
+            "et al" in tail_low
+            or "&" in tail
+            or re.search(r"\b[A-Z][a-zA-Z\-]+$", tail)
+        ):
+            title_with_authors = head
+    return year, title_with_authors.strip()
 
 
-def docx_word_count(path: Path) -> int:
-    doc = Document(str(path))
-    total = 0
-    for p in doc.paragraphs:
-        total += len(p.text.split())
-    for tbl in doc.tables:
-        for row in tbl.rows:
-            for cell in row.cells:
-                for p in cell.paragraphs:
-                    total += len(p.text.split())
-    return total
+def parse_book_folder_name(name: str) -> tuple[int | None, str]:
+    """Pull (year, title) from a 'My Books' folder name.  Year may be absent."""
+    m = re.match(r"^\s*(?:\((\d{4})\)\s*)?(.+?)\s*$", name)
+    if not m:
+        return None, name
+    year = int(m.group(1)) if m.group(1) else None
+    title = m.group(2).strip()
+    if ", " in title:
+        head, _, tail = title.rpartition(", ")
+        if "et al" in tail.lower() or "&" in tail:
+            title = head
+    return year, title
 
 
-def docx_page_count(path: Path) -> int | None:
-    """Pull pages from core/app properties.  Often absent until Word saves."""
-    doc = Document(str(path))
-    try:
-        props = doc.core_properties
-        if hasattr(props, "pages") and props.pages:
-            return int(props.pages)
-    except Exception:
-        pass
-    try:
-        app_props = doc.part.package.part_related_by.get("app")
-    except Exception:
-        app_props = None
-    return None
-
-
-def infer_journal_from_cv_in_review(title: str) -> str | None:
-    """If the CV's 'In Review' subsection lists this manuscript, try to
-    pull the journal name from the citation line."""
-    sections = load_cv_sections()
-    pub_lines = sections.get("PUBLICATIONS", [])
-    in_review_chunk = []
-    capture = False
-    for line in pub_lines:
-        if "In Review" in line and "In-Preparation" not in line:
-            capture = True
-            continue
-        if capture and "In-Preparation" in line:
-            break
-        if capture:
-            in_review_chunk.append(line)
-
-    title_norm = normalize_title(title)
-    for line in in_review_chunk:
-        if title_norm in normalize_title(line):
-            parts = re.split(r"\.\s+", line)
-            if parts:
-                last = parts[-1].strip().rstrip(".")
-                if 5 <= len(last) <= 80:
-                    return last
-    return None
+_journals_cache: set[str] | None = None
 
 
 def known_journals() -> set[str]:
-    df = pd.read_sql("SELECT DISTINCT journal FROM publication_stats", engine)
-    return {normalize_title(j) for j in df["journal"].dropna().tolist()}
+    """Cached set of normalized journal names already in publication_stats."""
+    global _journals_cache
+    if _journals_cache is None:
+        df = pd.read_sql("SELECT DISTINCT journal FROM publication_stats", engine)
+        _journals_cache = {normalize_title(j) for j in df["journal"].dropna().tolist()}
+    return _journals_cache
 
 
-# ---------------------------------------------------------------------------
-# Tracking table
-# ---------------------------------------------------------------------------
-def ensure_tracking_table() -> None:
-    with engine.begin() as conn:
-        conn.execute(text("""
-            CREATE TABLE IF NOT EXISTS academic_manuscript_tracking (
-                title_normalized TEXT PRIMARY KEY,
-                title TEXT,
-                status TEXT,
-                folder_path TEXT,
-                first_seen DATE,
-                last_updated DATE
-            )
-        """))
-
-
-def tracking_get(title_norm: str) -> dict | None:
-    with engine.connect() as conn:
-        row = conn.execute(
-            text("SELECT * FROM academic_manuscript_tracking WHERE title_normalized = :t"),
-            {"t": title_norm},
-        ).fetchone()
-    return dict(row._mapping) if row else None
-
-
-def tracking_upsert(title_norm: str, title: str, status: str, folder_path: str) -> None:
-    today = date.today()
-    existing = tracking_get(title_norm)
-    with engine.begin() as conn:
-        if existing:
-            conn.execute(text("""
-                UPDATE academic_manuscript_tracking
-                SET status = :s, folder_path = :f, last_updated = :d, title = :t
-                WHERE title_normalized = :n
-            """), {"s": status, "f": folder_path, "d": today, "t": title, "n": title_norm})
-        else:
-            conn.execute(text("""
-                INSERT INTO academic_manuscript_tracking
-                    (title_normalized, title, status, folder_path, first_seen, last_updated)
-                VALUES (:n, :t, :s, :f, :d, :d)
-            """), {"n": title_norm, "t": title, "s": status, "f": folder_path, "d": today})
+def remember_journal(journal: str) -> None:
+    """Add a freshly-inserted journal so subsequent rows in this run know it."""
+    if journal:
+        known_journals().add(normalize_title(journal))
 
 
 # ---------------------------------------------------------------------------
 # publication_stats read/write
 # ---------------------------------------------------------------------------
-def publication_row_by_title(title: str) -> dict | None:
-    title_norm = normalize_title(title)
-    with engine.connect() as conn:
-        rows = conn.execute(
-            text("SELECT ctid, * FROM publication_stats WHERE title IS NOT NULL")
-        ).fetchall()
-    for r in rows:
-        d = dict(r._mapping)
-        if normalize_title(d.get("title") or "") == title_norm:
-            return d
-    return None
-
-
-def ask_article_type() -> dict:
-    print("  article type?")
-    print("    1) theoretical")
-    print("    2) empirical")
-    print("    3) commentary / reply")
-    print("    4) book content")
-    while True:
-        c = prompt("  choice (1-4)", "2")
-        if c in {"1", "2", "3", "4"}:
-            break
-    return {
-        "theoretical_articles": 1 if c == "1" else 0,
-        "empirical_articles": 1 if c == "2" else 0,
-        "commentary_replies": 1 if c == "3" else 0,
-        "book_content": 1 if c == "4" else 0,
-    }
-
-
 def insert_publication_row(row: dict) -> None:
     cols = ", ".join(row.keys())
     placeholders = ", ".join(f":{k}" for k in row.keys())
@@ -473,121 +344,205 @@ def insert_publication_row(row: dict) -> None:
         conn.execute(text(f"INSERT INTO publication_stats ({cols}) VALUES ({placeholders})"), row)
 
 
-def update_publication_row(title: str, updates: dict) -> None:
-    set_clause = ", ".join(f"{k} = :{k}" for k in updates.keys())
-    params = dict(updates)
-    params["title"] = title
-    with engine.begin() as conn:
-        conn.execute(
-            text(f"UPDATE publication_stats SET {set_clause} WHERE title = :title"),
-            params,
-        )
-
-
 # ---------------------------------------------------------------------------
-# Manuscript processing
+# Article / book processing — DOI-keyed since 2026-05
+#
+# Articles are matched to existing publication_stats rows by DOI.  When a
+# DOI is found in the PDF and already attached to a row, the file is
+# silently skipped.  When the DOI is new, Crossref provides title / journal
+# / year / authors and a single Y/n prompt confirms insertion.  When DOI
+# extraction fails entirely, the file is reported and skipped (not auto-
+# inserted) — drop a manual row in publication_stats or run the backfill
+# script for those.
 # ---------------------------------------------------------------------------
-def process_manuscript(folder: Path, status: str, journal_hint: str | None) -> None:
-    title = folder.name
-    title_norm = normalize_title(title)
-    tracked = tracking_get(title_norm)
-    existing_row = publication_row_by_title(title)
+from doi_extract import extract_doi  # noqa: E402
+from crossref_lookup import lookup_doi_with_retry  # noqa: E402
 
-    if tracked and tracked["status"] == status and existing_row:
-        return
 
-    main_doc = find_main_docx(folder)
-    if main_doc is None:
-        print(f"\n[{status}] {title}")
-        print("  ⚠ could not locate main .docx — skipping")
-        return
+def load_db_doi_set() -> set[str]:
+    """All DOIs already attached to publication_stats rows."""
+    with engine.connect() as conn:
+        rows = conn.execute(
+            text("SELECT DISTINCT doi FROM publication_stats WHERE doi IS NOT NULL")
+        ).fetchall()
+    return {r[0].lower() for r in rows}
 
-    print(f"\n[{status}] {title}")
-    print(f"  main doc: {main_doc.name}")
 
-    try:
-        words = docx_word_count(main_doc)
-        pages = docx_page_count(main_doc)
-    except Exception as e:
-        print(f"  ⚠ could not read {main_doc.name} ({e}) — skipping")
-        return
-    if pages is None:
-        print(f"  words: {words}, pages not in metadata")
-        if prompt_yes_no(f"  use estimate ({words // 250} pages from words/250)?", True):
-            pages = max(1, words // 250)
-        else:
-            pages = prompt_int("  enter actual page count")
-    else:
-        print(f"  words: {words}, pages: {pages}")
+def load_db_titles() -> set[str]:
+    """Normalized titles in publication_stats — used for book-folder dedup
+    as a fallback when no ISBN match is found."""
+    with engine.connect() as conn:
+        rows = conn.execute(
+            text("SELECT title FROM publication_stats WHERE title IS NOT NULL")
+        ).fetchall()
+    return {normalize_title(r[0]) for r in rows}
 
-    journal = journal_hint
-    if not journal:
-        inferred = infer_journal_from_cv_in_review(title)
-        if inferred:
-            if prompt_yes_no(f"  journal '{inferred}' — correct?", True):
-                journal = inferred
-    if not journal:
-        journal = prompt("  journal name")
 
+def load_db_isbns() -> set[str]:
+    """All ISBNs already attached to publication_stats rows (digits only)."""
+    with engine.connect() as conn:
+        rows = conn.execute(
+            text("SELECT DISTINCT isbn FROM publication_stats WHERE isbn IS NOT NULL")
+        ).fetchall()
+    out: set[str] = set()
+    for r in rows:
+        digits = "".join(c for c in r[0] if c.isdigit())
+        if digits:
+            out.add(digits)
+    return out
+
+
+def isbn_in_folder_name(name: str) -> str | None:
+    """If an ISBN-13 (978...) appears in the folder name, return digits-only.
+    Most My Books/ folder names won't have this, but it's free to check."""
+    digits = "".join(c if c.isdigit() else " " for c in name).split()
+    for run in digits:
+        if len(run) == 13 and run.startswith("978"):
+            return run
+    return None
+
+
+def role_from_crossref_type(t: str | None) -> str:
+    return {
+        "journal-article": "article",
+        "book-chapter": "chapter",
+        "book": "author",
+        "monograph": "author",
+        "edited-book": "editor",
+        "posted-content": "preprint",
+        "report": "report",
+    }.get(t or "", "article")
+
+
+def article_type_from_crossref(t: str | None) -> dict:
+    """Default category flags inferred from Crossref's work type."""
+    if t == "book-chapter":
+        return {"theoretical_articles": 0, "empirical_articles": 0,
+                "commentary_replies": 0, "book_content": 1}
+    return {"theoretical_articles": 0, "empirical_articles": 1,
+            "commentary_replies": 0, "book_content": 0}
+
+
+def insert_from_crossref(crossref: dict, doi: str) -> None:
+    """Build and INSERT a publication_stats row from Crossref metadata."""
     journals = known_journals()
-    new_journal_auto = normalize_title(journal) not in journals
-    print(f"  '{journal}' {'NEW to catalog' if new_journal_auto else 'already in catalog'}")
-    if prompt_yes_no(f"  mark as new journal?", new_journal_auto):
-        new_journal_val = "Yes"
-        number_journals = 1
-    else:
-        new_journal_val = "No"
-        number_journals = 0
-
-    if existing_row:
-        updates = {
-            "number_words": words,
-            "number_pages": pages,
-            "journal": journal,
-            "new_journal": new_journal_val,
-            "number_journals": number_journals,
-        }
-        if status == "published":
-            if prompt_yes_no(
-                f"  update year from {existing_row.get('year')} to {CURRENT_YEAR}?",
-                False,
-            ):
-                updates["year"] = CURRENT_YEAR
-        update_publication_row(title, updates)
-        print(f"  ↻ updated publication_stats row")
-    else:
-        row = {
-            "year": CURRENT_YEAR,
-            "number_words": words,
-            "number_pages": pages,
-            "number_journals": number_journals,
-            "title": title,
-            "journal": journal,
-            "new_journal": new_journal_val,
-        }
-        row.update(ask_article_type())
-        insert_publication_row(row)
-        print(f"  + inserted publication_stats row")
-
-    tracking_upsert(title_norm, title, status, str(folder))
+    is_new_journal = (
+        bool(crossref.get("journal"))
+        and normalize_title(crossref["journal"]) not in journals
+    )
+    row = {
+        "year": crossref.get("year"),
+        "number_words": 0,
+        "number_pages": 0,
+        "number_journals": 1 if is_new_journal else 0,
+        "title": crossref.get("title"),
+        "journal": crossref.get("journal"),
+        "new_journal": "Yes" if is_new_journal else "No",
+        "authors": crossref.get("authors"),
+        "doi": doi,
+        "role": role_from_crossref_type(crossref.get("type")),
+    }
+    row.update(article_type_from_crossref(crossref.get("type")))
+    insert_publication_row(row)
+    if crossref.get("journal"):
+        remember_journal(crossref["journal"])
 
 
-def scan_under_review() -> None:
-    if not UNDER_REVIEW_DIR.exists():
-        print(f"warning: {UNDER_REVIEW_DIR} not found")
-        return
-    for folder in sorted(p for p in UNDER_REVIEW_DIR.iterdir() if p.is_dir()):
-        process_manuscript(folder, "under_review", None)
+def process_article_pdf(pdf_path: Path, doi_set: set[str]) -> str:
+    """Returns one of: 'skipped' (already known) / 'inserted' / 'no-doi'
+    / 'declined' / 'crossref-miss'."""
+    doi, src = extract_doi(pdf_path, allow_ocr=True)
+    if not doi:
+        # No DOI — flag once at end-of-run; don't insert anything.
+        return "no-doi"
+    if doi in doi_set:
+        return "skipped"
+
+    crossref = lookup_doi_with_retry(doi)
+    if not crossref:
+        print(f"\n[NEW article] {pdf_path.name}")
+        print(f"  DOI: {doi} ({src})")
+        print(f"  Crossref returned nothing — skipping (try the backfill script)")
+        return "crossref-miss"
+
+    print(f"\n[NEW article] {pdf_path.name}")
+    print(f"  DOI: {doi} ({src})")
+    print(f"    title:    {crossref.get('title')}")
+    print(f"    journal:  {crossref.get('journal')}")
+    print(f"    year:     {crossref.get('year')}")
+    print(f"    authors:  {crossref.get('authors')}")
+    print(f"    type:     {crossref.get('type')}")
+    if not prompt_yes_no("  insert as new publication_stats row?", True):
+        return "declined"
+
+    insert_from_crossref(crossref, doi)
+    doi_set.add(doi)
+    print("  + inserted publication_stats row")
+    return "inserted"
 
 
-def scan_published() -> None:
-    if not PUBLISHED_DIR.exists():
-        print(f"warning: {PUBLISHED_DIR} not found")
-        return
-    for journal_folder in sorted(p for p in PUBLISHED_DIR.iterdir() if p.is_dir()):
-        journal_name = journal_folder.name
-        for manuscript_folder in sorted(p for p in journal_folder.iterdir() if p.is_dir()):
-            process_manuscript(manuscript_folder, "published", journal_name)
+def process_book_folder(folder: Path, db_titles: set[str],
+                        db_isbns: set[str]) -> str:
+    """Match book folder to existing rows by ISBN (preferred) or title.
+    Folders that match neither are reported but NOT inserted to avoid
+    duplicates — ISBN entry needs a human anyway."""
+    _, title = parse_book_folder_name(folder.name)
+    if not title:
+        return "skipped"
+    folder_isbn = isbn_in_folder_name(folder.name)
+    if folder_isbn and folder_isbn in db_isbns:
+        return "skipped"
+    if normalize_title(title) in db_titles:
+        return "skipped"
+    return "no-match"
+
+
+def scan_articles(doi_set: set[str]) -> dict[str, int]:
+    counts = {"skipped": 0, "inserted": 0, "no-doi": 0,
+              "declined": 0, "crossref-miss": 0}
+    if not ARTICLES_DIR.exists():
+        print(f"warning: {ARTICLES_DIR} not found")
+        return counts
+    pdfs = sorted(p for p in ARTICLES_DIR.glob("*.pdf"))
+    no_doi_files: list[str] = []
+    for pdf in pdfs:
+        result = process_article_pdf(pdf, doi_set)
+        counts[result] += 1
+        if result == "no-doi":
+            no_doi_files.append(pdf.name)
+    print(f"  scanned {len(pdfs)} article PDFs: "
+          f"{counts['skipped']} known, {counts['inserted']} inserted, "
+          f"{counts['no-doi']} no-DOI, {counts['declined']} declined, "
+          f"{counts['crossref-miss']} crossref-miss")
+    if no_doi_files:
+        print("  PDFs without an extractable DOI (manual entry needed):")
+        for f in no_doi_files:
+            print(f"    {f}")
+    return counts
+
+
+def scan_books(db_titles: set[str], db_isbns: set[str]) -> dict[str, int]:
+    counts = {"skipped": 0, "no-match": 0}
+    if not BOOKS_DIR.exists():
+        print(f"warning: {BOOKS_DIR} not found")
+        return counts
+    folders = sorted(
+        p for p in BOOKS_DIR.iterdir()
+        if p.is_dir() and not p.name.startswith(".") and p.name.lower() != "icon"
+    )
+    unmatched: list[str] = []
+    for f in folders:
+        result = process_book_folder(f, db_titles, db_isbns)
+        counts[result] += 1
+        if result == "no-match":
+            unmatched.append(f.name)
+    print(f"  scanned {len(folders)} book folders: "
+          f"{counts['skipped']} known, {counts['no-match']} not yet in DB")
+    if unmatched:
+        print("  Book folders not in DB (add via backfill or manual entry):")
+        for n in unmatched:
+            print(f"    {n}")
+    return counts
 
 
 # ---------------------------------------------------------------------------
@@ -697,7 +652,6 @@ def main() -> int:
         return 1
 
     print(f"=== academic data update — {date.today()} ===")
-    ensure_tracking_table()
 
     state = load_state()
 
@@ -719,10 +673,16 @@ def main() -> int:
     print(f"\npopular media delta since last run: {media_delta}")
     state["popular_media_totals"] = media_totals
 
-    print("\nscanning Manuscripts Under Review...")
-    scan_under_review()
-    print("\nscanning Manuscripts With Decisions / Published...")
-    scan_published()
+    doi_set = load_db_doi_set()
+    db_titles = load_db_titles()
+    db_isbns = load_db_isbns()
+    print(f"\npublication_stats: {len(db_titles)} rows, "
+          f"{len(doi_set)} with DOIs, {len(db_isbns)} with ISBNs")
+
+    print("\nscanning Articles/My Articles...")
+    scan_articles(doi_set)
+    print("\nscanning Articles/My Books...")
+    scan_books(db_titles, db_isbns)
 
     deltas = seasonal_prompts(state)
     update_cv_additions(cv_counts, deltas, media_delta)


### PR DESCRIPTION
## Summary

### Baseball duplicate-entry fix (`05ac322`)
- DB unique index on `baseball_watched_long(date, box_score)` as the definitive backstop
- Insert switched to `ON CONFLICT DO NOTHING`
- Server-side re-entry lock in `/submit` and `/no-games`
- Client-side `onsubmit` disables form buttons to block double-clicks

### Weekly cleanup (`c059366`)
- Launch Agent self-monitoring (`agent_health.py`) wired into `run_all` with auto-heal + Ntfy push when stale `davidjcox.*` agents are rebootstrapped
- Academic tracker rewritten to scan `Dropbox/Articles/My Articles` and `My Books` instead of the old Manuscripts directories
- Spotify weekly converter: cap `ms_played` at 30s (Spotify's play-count threshold) instead of full track duration; ESH exports overwrite later
- New helpers: `ntfy.py`, `doi_extract.py`, `crossref_lookup.py`, `openlibrary_lookup.py`, `laptop_health_summary.py`
- Backfill scripts for publications and books
- Gitignore generated `plots/*.b64` and the academic prompt state sidecar

### Earlier dev commit (`c659b30`)
- run_all pipeline fixes + academic data tracker (already on dev)

## Test plan
- [ ] Baseball form: single submit, double-click, refresh-resubmit, manual duplicate POST — only one row per (date, box_score)
- [ ] `run_all.py` completes end-to-end and surfaces Launch Agent health summary
- [ ] Stale agent triggers Ntfy auto-heal notification
- [ ] Academic tracker picks up new items from `My Articles` / `My Books`
- [ ] Spotify weekly run inserts rows with `ms_played = 30000` for API-sourced plays
- [ ] No regressions in dashboard rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)
