### PR TITLE
Auto-create Time Tracking and Archive dirs in aggregation script

### DIFF
--- a/Scripts/aggregate_time_allocation_data.py
+++ b/Scripts/aggregate_time_allocation_data.py
@@ -25,6 +25,10 @@ raw_data_path = '../Data/raw_data.csv'  # Path to the raw_data.csv file
 script_dir = os.path.dirname(os.path.abspath(__file__))
 archive_path = os.path.join(script_dir, '..', 'Archive')
 
+# Ensure the working directories exist (fresh checkouts may not have them)
+os.makedirs(folder_path, exist_ok=True)
+os.makedirs(archive_path, exist_ok=True)
+
 # Download new files from Dropbox shared folder
 DROPBOX_URL = os.getenv("DROPBOX_TIME_TRACKING_URL")
 if DROPBOX_URL:


### PR DESCRIPTION
## Summary
On a fresh checkout, `Data/Time Tracking/` does not exist, so `aggregate_time_allocation_data.py` fails with `FileNotFoundError` when the Dropbox download tries to write into it. This adds `os.makedirs(..., exist_ok=True)` for both the Time Tracking and Archive directories at startup, making the script self-healing on new machines.

## Context
Surfaced while setting up `run_all.py` on a new computer. After this fix (plus rebuilding the venv on Python 3.12 to match `requirements.txt`), the full pipeline runs end-to-end with exit code 0.

## Test plan
- [x] `run_all.py` completes successfully end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)