### PR TITLE
Harden time-tracking aggregation and pin PDF deps

### DIFF
--- a/Scripts/aggregate_time_allocation_data.py
+++ b/Scripts/aggregate_time_allocation_data.py
@@ -152,9 +152,13 @@ new_df = new_df.drop_duplicates().sort_values(
     by=['date_column'], ascending=True).reset_index(drop=True)
 
 # Add new data to the existing raw_data.csv data
-all_data['date_column'] = pd.to_datetime(all_data['date_column'])
-all_data = pd.concat([all_data, new_df]).drop_duplicates(
-    subset='date_column', keep='first').reset_index(drop=True)
+if all_data.empty:
+    # Fresh checkout: raw_data.csv didn't exist, so start from the new files
+    all_data = new_df.copy()
+else:
+    all_data['date_column'] = pd.to_datetime(all_data['date_column'])
+    all_data = pd.concat([all_data, new_df]).drop_duplicates(
+        subset='date_column', keep='first').reset_index(drop=True)
 
 # Sort by date
 all_data['date_column'] = pd.to_datetime(all_data['date_column'])

--- a/Scripts/aggregate_time_allocation_data.py
+++ b/Scripts/aggregate_time_allocation_data.py
@@ -21,7 +21,6 @@ DB_URL = os.getenv("DB_URL")
 
 # Paths
 folder_path = '../Data/Time Tracking/'  # Folder with the data files
-raw_data_path = '../Data/raw_data.csv'  # Path to the raw_data.csv file
 script_dir = os.path.dirname(os.path.abspath(__file__))
 archive_path = os.path.join(script_dir, '..', 'Archive')
 
@@ -65,12 +64,6 @@ if DROPBOX_URL:
         print("Continuing with local files...")
 else:
     print("Warning: DROPBOX_TIME_TRACKING_URL not set in .env, skipping Dropbox download.")
-
-# Read existing data from raw_data.csv
-if os.path.exists(raw_data_path):
-    all_data = pd.read_csv(raw_data_path)
-else:
-    all_data = pd.DataFrame()
 
 # Data processing
 new_df = pd.DataFrame()
@@ -150,25 +143,6 @@ if new_df.empty:
 # Ensure new_df has unique rows and reset the index
 new_df = new_df.drop_duplicates().sort_values(
     by=['date_column'], ascending=True).reset_index(drop=True)
-
-# Add new data to the existing raw_data.csv data
-if all_data.empty:
-    # Fresh checkout: raw_data.csv didn't exist, so start from the new files
-    all_data = new_df.copy()
-else:
-    all_data['date_column'] = pd.to_datetime(all_data['date_column'])
-    all_data = pd.concat([all_data, new_df]).drop_duplicates(
-        subset='date_column', keep='first').reset_index(drop=True)
-
-# Sort by date
-all_data['date_column'] = pd.to_datetime(all_data['date_column'])
-all_data = all_data.sort_values(
-    by=['date_column'], ascending=True).reset_index(drop=True)
-
-# Save the updated data back to raw_data.csv
-all_data = all_data.drop_duplicates(subset=['date_column'], keep='last')
-all_data.to_csv(raw_data_path, index=False)
-print("Data has been successfully appended to the raw_data.csv file.")
 
 # Database connection details
 TABLE_NAME = 'raw_data'

--- a/requirements.txt
+++ b/requirements.txt
@@ -72,6 +72,10 @@ packaging==25.0
 pandas==2.2.3
 pandocfilters==1.5.1
 parso==0.8.4
+pdfminer.six==20251230
+pdfplumber==0.11.9
+pypdf==6.13.2
+pypdfium2==5.9.0
 plotly==6.5.0
 pexpect==4.9.0
 pillow==11.2.1


### PR DESCRIPTION
## Summary

Fixes the failures seen when running `run_all.py` on a fresh checkout, and simplifies the time-tracking aggregation to use the database as the single source of truth.

- **Auto-create working dirs** (`9c1afc9`): create `Data/Time Tracking/` and `Archive/` if missing, so a fresh checkout doesn't fail before downloading.
- **Pin PDF deps** (`bb15c74`): add `pdfplumber`, `pypdf`, and their transitive deps (`pdfminer.six`, `pypdfium2`) to `requirements.txt`. `doi_extract.py` imports these for the academic-data update; the venv was built before they were pinned, causing `ModuleNotFoundError`.
- **Drop redundant `raw_data.csv`** (`5ba9c9c`): nothing downstream reads the CSV — the dashboard (`app.py`) and ML prep (`unsupervised_ml_data_prep.py`) both read the `raw_data` DB table, which the script already self-dedups via `remove_duplicates_query` after each append. The CSV was only an intermediate dedup base for this one script, and a missing CSV crashed it (`KeyError: 'date_column'`). Removing it makes the DB the single source of truth and eliminates CSV-vs-DB drift.

## Testing

- `aggregate_time_allocation_data.py` runs end-to-end (downloads, appends to DB, dedups, archives) with no CSV involved.
- `update_academic_data.py` imports cleanly and reaches its interactive insert prompt (no more `ModuleNotFoundError`).
- Script compiles clean; no leftover references to the removed CSV path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)