### PR TITLE
Daily change-digest, clustering data enrichment, and plot axis fixes

### DIFF
--- a/LaunchAgents/com.davidjcox.daily-digest.plist
+++ b/LaunchAgents/com.davidjcox.daily-digest.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.davidjcox.daily-digest</string>
+
+    <!-- Headless morning refresh: pulls all sources, rebuilds the clustering
+         data + CSV, then builds and pushes the daily digest via Ntfy (run_all.py
+         in --no-dashboard mode skips the blocking Dash app). WorkingDirectory is
+         Scripts/ because run_all.py invokes sibling scripts by bare name and uses
+         ../Data relative paths. The CLAUDE_CODE_OAUTH_TOKEN is read from .env by
+         daily_digest.py (load_dotenv), so no secret lives in this plist. -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/davidjcox/Documents/SideProjects/quantified-self-app/venv/bin/python3.12</string>
+        <string>/Users/davidjcox/Documents/SideProjects/quantified-self-app/Scripts/run_all.py</string>
+        <string>--no-dashboard</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/davidjcox/Documents/SideProjects/quantified-self-app/Scripts</string>
+
+    <!-- Fire daily at 6:00 AM (after the 5:00 AM data-entry jobs). If the Mac was
+         asleep at 6:00, launchd runs the job as soon as it next wakes. -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>6</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <!-- Also run at load: StartCalendarInterval does not catch up a missed run if
+         the Mac was fully powered OFF at 6:00 (only after sleep). Safe to re-run;
+         the digest is read-only apart from the push. -->
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- Logs under ~/Library/Logs (NOT ~/Documents, which is TCC-protected and
+         silently blocks launchd from opening files there). -->
+    <key>StandardOutPath</key>
+    <string>/Users/davidjcox/Library/Logs/daily-digest/daily_digest.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/davidjcox/Library/Logs/daily-digest/daily_digest.err.log</string>
+
+    <key>ProcessType</key>
+    <string>Interactive</string>
+</dict>
+</plist>

--- a/LaunchAgents/com.davidjcox.daily-digest.plist
+++ b/LaunchAgents/com.davidjcox.daily-digest.plist
@@ -7,7 +7,7 @@
 
     <!-- Headless morning refresh: pulls all sources, rebuilds the clustering
          data + CSV, then builds and pushes the daily digest via Ntfy (run_all.py
-         in --no-dashboard mode skips the blocking Dash app). WorkingDirectory is
+         in no-dashboard mode skips the blocking Dash app). WorkingDirectory is
          Scripts/ because run_all.py invokes sibling scripts by bare name and uses
          ../Data relative paths. The CLAUDE_CODE_OAUTH_TOKEN is read from .env by
          daily_digest.py (load_dotenv), so no secret lives in this plist. -->

--- a/Scripts/agent_health.py
+++ b/Scripts/agent_health.py
@@ -74,11 +74,30 @@ def _list_loaded_agents() -> set[str]:
     return loaded
 
 
-def _read_plist(path: Path) -> dict:
+def _read_plist(path: Path) -> dict | None:
+    """Parse a plist, returning its dict or None if it can't be read.
+
+    launchd tolerates malformed XML (e.g. a literal '--' inside a comment,
+    which is illegal XML but loads fine); Python's strict plistlib does not.
+    On a parse failure we fall back to `plutil`, which is as lenient as
+    launchd, so a cosmetic plist defect can't blind the health check and
+    trigger a false-stale eviction.  Returns None (not {}) on total failure
+    so callers can distinguish "unreadable" from "read, but empty".
+    """
     try:
         return plistlib.loads(path.read_bytes()) or {}
     except Exception:
-        return {}
+        pass
+    try:
+        out = subprocess.run(
+            ["plutil", "-convert", "xml1", "-o", "-", str(path)],
+            capture_output=True, timeout=15,
+        )
+        if out.returncode == 0 and out.stdout:
+            return plistlib.loads(out.stdout) or {}
+    except (subprocess.TimeoutExpired, FileNotFoundError, Exception):
+        pass
+    return None
 
 
 def _latest_log_mtime(plist: dict) -> float | None:
@@ -107,6 +126,18 @@ def check_all() -> list[dict]:
     out = []
     for plist_path in sorted(LAUNCH_AGENTS_DIR.glob(f"{AGENT_PREFIX}*.plist")):
         plist = _read_plist(plist_path)
+        if plist is None:
+            # Unreadable plist: never flag stale (a false-stale would trigger
+            # a bootout/bootstrap and could evict a healthy, running agent).
+            out.append({
+                "label": plist_path.stem,
+                "plist_path": str(plist_path),
+                "loaded": plist_path.stem in loaded,
+                "last_seen_minutes": None,
+                "cadence_minutes": None,
+                "stale": False,
+            })
+            continue
         label = plist.get("Label") or plist_path.stem
         mtime = _latest_log_mtime(plist)
         cadence = EXPECTED_CADENCE.get(label, 86400)
@@ -168,7 +199,7 @@ def rebootstrap(plist_path: str) -> tuple[bool, str]:
     p = Path(plist_path)
     if not p.exists():
         return False, f"plist not found: {plist_path}"
-    label = _read_plist(p).get("Label", p.stem)
+    label = (_read_plist(p) or {}).get("Label", p.stem)
     domain = f"gui/{_gui_uid()}"
     # bootout: harmless if not loaded (returns non-zero, we ignore).
     subprocess.run(

--- a/Scripts/app.py
+++ b/Scripts/app.py
@@ -11,6 +11,7 @@ import pandas as pd
 import numpy as np
 
 from clustering_features import clustering_numeric_frame, write_clustering_csv
+from regime_clustering import build_recent_regimes
 
 # System
 import base64
@@ -2746,6 +2747,9 @@ if not model_df.empty:
     # Drop columns with more than 40% missing data
     missing_fraction = df_numeric.isnull().mean()
     df_numeric = df_numeric.loc[:, missing_fraction <= 0.4]
+
+    # Tier 2: labeled day-regimes over the recent multi-domain dense window.
+    recent_regimes = build_recent_regimes(model_df)
 else:
     clustering_image_base64 = generate_placeholder_image("No clustering data available.")
     pca_feature_importance_images = []
@@ -2755,6 +2759,54 @@ else:
     recurrence_plot_base64 = generate_placeholder_image("No recurrence plot available.")
     rqa_metrics = {}
     rqa_interpretation = []
+    recent_regimes = {'ok': False, 'reason': 'no modeling data available'}
+
+
+# Build the Recent Regimes (Tier 2) tab content from the regime artifacts.
+if recent_regimes.get('ok'):
+    _rr = recent_regimes
+    _t = _rr['transitions']
+    _regime_summary = (
+        f"Recent dense window {_rr['window_start']} to {_rr['window_end']}: "
+        f"{_t['n_days']} days grouped into {_rr['k']} regimes "
+        f"(silhouette {_rr['silhouette']}), with {_t['n_transitions']} transitions. "
+        f"Currently {_t['current_regime']} for {_t['current_run_days']} day(s). "
+        f"Built on {_rr['n_features']} multi-domain features (food included; "
+        f"running and golf enter as honest ran/golfed flags)."
+    )
+    regime_tab_children = [html.Div(children=[
+        html.H3("Recent Day-Regimes", style={'textAlign': 'center'}),
+        html.P(_regime_summary,
+               style={'textAlign': 'center', 'fontSize': 14, 'color': 'gray',
+                      'width': '80%', 'margin': '0 auto', 'marginBottom': '2rem'}),
+        html.Img(src=f'data:image/png;base64,{_rr["timeline_b64"]}',
+                 style={'display': 'block', 'width': '92%', 'margin': '0 auto',
+                        'margin-bottom': '3rem'}),
+        html.Img(src=f'data:image/png;base64,{_rr["embedding_b64"]}',
+                 style={'display': 'block', 'width': '55%', 'margin': '0 auto',
+                        'margin-bottom': '3rem'}),
+        html.H3("Regime Profiles", style={'textAlign': 'center'}),
+        html.P("How each regime's days sit relative to a typical window day.",
+               style={'textAlign': 'center', 'fontSize': 14, 'color': 'gray',
+                      'marginBottom': '1rem'}),
+        dash_table.DataTable(
+            data=_rr['profiles'].to_dict('records'),
+            columns=[{'name': c, 'id': c} for c in _rr['profiles'].columns],
+            style_table={'width': '90%', 'margin': '0 auto', 'marginBottom': '4rem'},
+            style_cell={'textAlign': 'left', 'fontSize': 14, 'padding': '10px',
+                        'whiteSpace': 'normal', 'maxWidth': '320px'},
+            style_header={'fontWeight': 'bold', 'fontSize': 16, 'textAlign': 'center'},
+            style_data_conditional=[
+                {'if': {'column_id': 'Regime'}, 'fontWeight': 'bold',
+                 'textAlign': 'center'}],
+        ),
+    ], style={'textAlign': 'center'})]
+else:
+    regime_tab_children = [html.Div(children=[
+        html.H3("Recent Day-Regimes", style={'textAlign': 'center'}),
+        html.P(f"Not available yet: {recent_regimes.get('reason', 'unknown')}.",
+               style={'textAlign': 'center', 'color': 'gray', 'marginTop': '2rem'}),
+    ], style={'textAlign': 'center'})]
 
 app.layout = html.Div(children=[
     dcc.Tabs(id='tabs', value='OVR Data', children=[
@@ -2856,6 +2908,9 @@ app.layout = html.Div(children=[
                 ], style={'width': '70%', 'margin': '0 auto', 'marginBottom': '6rem'}),
             ], style={'textAlign': 'center'})
         ]),
+
+        dcc.Tab(label='Recent Regimes', value='Recent Regimes',
+                children=regime_tab_children),
 
         # Baseball Data
         dcc.Tab(label="Baseball Watched", children=[

--- a/Scripts/app.py
+++ b/Scripts/app.py
@@ -10,6 +10,8 @@ from IPython.display import display, HTML
 import pandas as pd
 import numpy as np
 
+from clustering_features import clustering_numeric_frame, write_clustering_csv
+
 # System
 import base64
 from io import BytesIO
@@ -1013,10 +1015,12 @@ def plot_run_mins_mile_month():
 
     # Plotting
     fig, ax = plt.subplots(figsize=(20, 8))
+    n_years = plot_df['Year'].nunique()
     sns.boxplot(
         x=plot_df['Month'],
         y=plot_df['Min per Mile'],
         hue=plot_df['Year'],
+        palette=sns.color_palette('husl', n_colors=n_years),
         showfliers=False,
     )
     plt.xlabel("Month", fontsize=26, labelpad=12)
@@ -1025,7 +1029,8 @@ def plot_run_mins_mile_month():
     plt.yticks(fontsize=16)
     plt.ylim(6, 10)
     sns.despine(top=True, right=True)
-    plt.legend(frameon=False, loc="best", fontsize=12)
+    plt.legend(frameon=False, loc="upper left", fontsize=11, title="Year",
+               ncol=3, columnspacing=1.0, handletextpad=0.4)
 
     # Save the plot to a bytes buffer
     plt.tight_layout()
@@ -2650,6 +2655,14 @@ def plot_golf_scores_handicap():
     ax1.tick_params(axis='x', labelsize=12)
     ax1.tick_params(axis='y', labelsize=12, colors='black')
 
+    # Thin out and angle date ticks so they don't overlap
+    ax1.xaxis.set_major_locator(mdates.AutoDateLocator(minticks=4, maxticks=8))
+    ax1.xaxis.set_major_formatter(
+        mdates.ConciseDateFormatter(ax1.xaxis.get_major_locator(), show_offset=False))
+    for label in ax1.get_xticklabels():
+        label.set_rotation(45)
+        label.set_ha('right')
+
     # Handicap index on secondary y-axis
     ax2 = ax1.twinx()
     valid_hc = plot_df.dropna(subset=['handicap'])
@@ -2681,24 +2694,12 @@ app = Dash(__name__)
 
 # After loading model_df, generate the clustering plot statically
 if not model_df.empty:
-    # Prep the data - use only numeric columns and exclude derived/redundant columns
-    exclude_columns = ['date_column', 'Year', 'Month_Num', 'Day', 'DayOfYear', 'nap', 'total',
-                       'ovr_pirates', 'ovr_guardians', 'ovr_other', 'cycle_id']
-    # Exclude Whoop metadata/timing columns but keep score_ columns (sleep, recovery, strain, HR, HRV)
-    exclude_columns += [col for col in model_df.columns if col.startswith('updated_at_')]
-    exclude_columns += [col for col in model_df.columns if col.endswith('_minutes_into_day')]
-    # Exclude duplicated zone duration columns (keep zone_duration_, drop zone_durations_)
-    exclude_columns += [col for col in model_df.columns if 'zone_durations_' in col]
-    # Exclude no-data and percent_recorded metadata
-    exclude_columns += [col for col in model_df.columns if 'no_data' in col or 'percent_recorded' in col]
-    numeric_columns = model_df.select_dtypes(include=['float64', 'int64']).columns
-    df_numeric = model_df[numeric_columns].drop(columns=exclude_columns, errors='ignore')
-    df_numeric = df_numeric.loc[:, (df_numeric != 0).any(axis=0)]
-    df_numeric = df_numeric.loc[:, df_numeric.notna().any(axis=0)]
-    df_numeric = df_numeric.fillna(0)
-    save_df = df_numeric.copy()
-    save_df['date_column'] = model_df['date_column']
-    save_df.to_csv(os.path.join(os.path.dirname(__file__), '..', 'Data', 'df_numeric_for_clustering.csv'))
+    # Project to the clustering matrix and persist it (shared with the daily
+    # refresh in unsupervised_ml_data_prep.py -- see clustering_features.py).
+    df_numeric = clustering_numeric_frame(model_df)
+    write_clustering_csv(
+        model_df,
+        os.path.join(os.path.dirname(__file__), '..', 'Data', 'df_numeric_for_clustering.csv'))
     scaler = MinMaxScaler()
     df_scaled = pd.DataFrame(scaler.fit_transform(df_numeric), columns=df_numeric.columns)
 

--- a/Scripts/clustering_features.py
+++ b/Scripts/clustering_features.py
@@ -1,0 +1,57 @@
+"""Shared projection from the full modeling frame to the clustering feature matrix.
+
+Both app.py (which runs the clustering) and unsupervised_ml_data_prep.py (which
+writes the CSV on the daily refresh) need the exact same projection, so it lives
+here as one source of truth. Previously it was duplicated in both files.
+
+The projection keeps numeric columns, drops derived/metadata/redundant ones, and
+fills remaining gaps with 0 -- which is only sound for columns where 0 is a real
+value (e.g. minutes spent, counts). Columns where missing != 0 and 0 would be
+actively misleading (rate/score metrics like run pace and golf differential) are
+excluded here and left as honest NaN in modeling_data.csv instead.
+"""
+
+# Rate/score metrics where 0 is meaningless (0 min/mi reads as infinitely fast,
+# 0 differential reads as a scratch golfer). Excluded from the clustering matrix.
+RATE_LIKE_EXCLUDE = ['run_pace', 'golf_differential']
+
+# Always-excluded derived / identifier / label columns.
+BASE_EXCLUDE = ['date_column', 'Year', 'Month_Num', 'Day', 'DayOfYear', 'nap',
+                'total', 'ovr_pirates', 'ovr_guardians', 'ovr_other', 'cycle_id']
+
+
+def clustering_feature_columns(model_df):
+    """Return the list of columns to exclude from the clustering matrix."""
+    exclude = list(BASE_EXCLUDE) + list(RATE_LIKE_EXCLUDE)
+    # Whoop metadata/timing (keep score_ columns: sleep, recovery, strain, HR, HRV).
+    exclude += [c for c in model_df.columns if c.startswith('updated_at_')]
+    exclude += [c for c in model_df.columns if c.endswith('_minutes_into_day')]
+    # Duplicated zone-duration columns (keep zone_duration_, drop zone_durations_).
+    exclude += [c for c in model_df.columns if 'zone_durations_' in c]
+    # No-data / percent_recorded metadata.
+    exclude += [c for c in model_df.columns if 'no_data' in c or 'percent_recorded' in c]
+    return exclude
+
+
+def clustering_numeric_frame(model_df):
+    """Project model_df to the numeric clustering matrix (no date_column).
+
+    Returns a frame on model_df's index: numeric columns only, derived/metadata
+    columns dropped, all-zero and all-NaN columns dropped, remaining NaNs filled
+    with 0. Callers that persist it add date_column back.
+    """
+    exclude = clustering_feature_columns(model_df)
+    numeric_columns = model_df.select_dtypes(include=['float64', 'int64']).columns
+    df = model_df[numeric_columns].drop(columns=exclude, errors='ignore')
+    df = df.loc[:, (df != 0).any(axis=0)]      # drop all-zero columns
+    df = df.loc[:, df.notna().any(axis=0)]     # drop all-NaN columns
+    df = df.fillna(0)
+    return df
+
+
+def write_clustering_csv(model_df, path):
+    """Build the clustering matrix and write it to path with date_column attached."""
+    save_df = clustering_numeric_frame(model_df).copy()
+    save_df['date_column'] = model_df['date_column']
+    save_df.to_csv(path)
+    return save_df

--- a/Scripts/daily_digest.py
+++ b/Scripts/daily_digest.py
@@ -1,0 +1,697 @@
+#!/usr/bin/env python
+"""Daily change-digest: how did yesterday compare to the trailing four weeks?
+
+This is the deterministic stats core. It assembles a unified daily metric
+matrix from every available source, then computes each metric's deviation
+from its own trailing-28-day baseline for a given as-of date (default:
+yesterday). The output is a ranked, structured list of changes that a
+narration layer turns into a morning push -- the stats live here, never in
+the LLM.
+
+Sources (per the v1 "everything" scope):
+  - df_numeric_for_clustering.csv : time-allocation levers + Whoop outcomes
+  - Postgres food_entries/items   : daily nutrient totals (levers)
+  - Postgres strava_activities    : running pace, min/mile (outcome)
+  - Postgres golf_scores          : 18-hole differential (outcome)
+
+Each metric is tagged lever vs. outcome and given a "good direction" so the
+narrator can say better/worse, not just up/down. Levers are things you choose
+today (food, hours); outcomes are results you cannot set directly (HRV, pace).
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from dotenv import load_dotenv
+from sqlalchemy import create_engine
+
+load_dotenv()
+
+DATA_DIR = Path(__file__).resolve().parent.parent / "Data"
+CSV_PATH = DATA_DIR / "df_numeric_for_clustering.csv"
+
+# Baseline window and minimum observations needed to trust a baseline.
+BASELINE_DAYS = 28
+MIN_OBS = 5
+# A category counts as "tracked" only with at least this many nonzero days in
+# the window. This is what makes untracked/sparse categories a non-issue: a
+# metric a person never logs is silently excluded instead of reading as
+# "dropped to 0". (Postgres sources store missing days as NaN; time-allocation
+# stores them as 0 -- the nonzero gate handles both uniformly.)
+MIN_ACTIVE = 3
+
+# --------------------------------------------------------------------------
+# Metric registry
+# --------------------------------------------------------------------------
+# kind:      'lever'  -> behavior you choose today (eligible for prospective focus)
+#            'outcome'-> result you cannot set directly
+# direction: +1 higher is better, -1 lower is better, 0 contextual/neutral
+# Each entry: key -> (label, domain, kind, direction, unit)
+METRICS = {
+    # --- Food levers (Postgres daily nutrient totals) ---
+    "calories":      ("Calories", "food", "lever", 0, "kcal"),
+    "protein_g":     ("Protein", "food", "lever", +1, "g"),
+    "carbs_g":       ("Carbs", "food", "lever", 0, "g"),
+    "fat_g":         ("Total fat", "food", "lever", 0, "g"),
+    "sat_fat_g":     ("Saturated fat", "food", "lever", -1, "g"),
+    "fiber_g":       ("Fiber", "food", "lever", +1, "g"),
+    "sugar_g":       ("Sugar", "food", "lever", -1, "g"),
+    "sodium_mg":     ("Sodium", "food", "lever", -1, "mg"),
+    "iron_mg":       ("Iron", "food", "lever", +1, "mg"),
+    "calcium_mg":    ("Calcium", "food", "lever", +1, "mg"),
+    "magnesium_mg":  ("Magnesium", "food", "lever", +1, "mg"),
+    "potassium_mg":  ("Potassium", "food", "lever", +1, "mg"),
+    # --- Time-allocation levers (CSV, minutes/day) ---
+    "coding":          ("Coding", "time", "lever", +1, "min"),
+    "writing":         ("Writing", "time", "lever", +1, "min"),
+    "reading_books":   ("Reading books", "time", "lever", +1, "min"),
+    "exercise":        ("Physical exercise", "time", "lever", +1, "min"),
+    "family":          ("Family", "time", "lever", +1, "min"),
+    "learning":        ("Learning", "time", "lever", +1, "min"),
+    "research":        ("Research projects", "time", "lever", +1, "min"),
+    "journal_articles":("Journal articles", "time", "lever", +1, "min"),
+    "teaching":        ("Teaching", "time", "lever", +1, "min"),
+    "hobbies":         ("Hobbies", "time", "lever", +1, "min"),
+    # --- Whoop outcomes (CSV) ---
+    "recovery":          ("Recovery", "whoop", "outcome", +1, "%"),
+    "hrv":               ("HRV (RMSSD)", "whoop", "outcome", +1, "ms"),
+    "resting_hr":        ("Resting HR", "whoop", "outcome", -1, "bpm"),
+    "strain":            ("Strain", "whoop", "outcome", 0, ""),
+    "sleep_hours":       ("Sleep duration", "whoop", "outcome", +1, "h"),
+    "sleep_performance": ("Sleep performance", "whoop", "outcome", +1, "%"),
+    "sleep_consistency": ("Sleep consistency", "whoop", "outcome", +1, "%"),
+    "sleep_efficiency":  ("Sleep efficiency", "whoop", "outcome", +1, "%"),
+    "respiratory_rate":  ("Respiratory rate", "whoop", "outcome", 0, "rpm"),
+    # --- Activity / golf outcomes (Postgres) ---
+    "run_pace":          ("Running pace", "running", "outcome", -1, "min/mi"),
+    "golf_differential": ("Golf differential", "golf", "outcome", -1, ""),
+}
+
+# Mapping of CSV source columns -> metric keys (direct copies).
+_CSV_COLUMN_MAP = {
+    "Coding": "coding",
+    "Writing": "writing",
+    "Reading Books": "reading_books",
+    "Physical Exercise": "exercise",
+    "Family": "family",
+    "Learning": "learning",
+    "Research Projects": "research",
+    "Journal Articles": "journal_articles",
+    "Teaching": "teaching",
+    "Hobbies": "hobbies",
+    "score_recovery_score": "recovery",
+    "score_hrv_rmssd_milli": "hrv",
+    "score_resting_heart_rate": "resting_hr",
+    "score_strain": "strain",
+    "score_sleep_performance_percentage": "sleep_performance",
+    "score_sleep_consistency_percentage": "sleep_consistency",
+    "score_sleep_efficiency_percentage": "sleep_efficiency",
+    "score_respiratory_rate": "respiratory_rate",
+}
+
+
+def _make_engine():
+    """Build a Postgres engine from .env, or return None if unconfigured."""
+    user, pw = os.getenv("DB_USER"), os.getenv("DB_PASSWORD")
+    host, port, name = os.getenv("DB_HOST"), os.getenv("DB_PORT"), os.getenv("DB_NAME")
+    if not all([user, pw, host, port, name]):
+        return None
+    return create_engine(f"postgresql://{user}:{pw}@{host}:{port}/{name}")
+
+
+# --------------------------------------------------------------------------
+# Per-source daily frames (each indexed by a normalized date)
+# --------------------------------------------------------------------------
+def _csv_daily(csv_path=CSV_PATH):
+    """Time-allocation levers + Whoop outcomes from the clustering CSV."""
+    if not Path(csv_path).exists():
+        return pd.DataFrame()
+    df = pd.read_csv(csv_path, index_col=0)
+    if "date_column" not in df.columns:
+        return pd.DataFrame()
+    df["date"] = pd.to_datetime(df["date_column"]).dt.normalize()
+    out = pd.DataFrame(index=df.index)
+    for src, key in _CSV_COLUMN_MAP.items():
+        if src in df.columns:
+            out[key] = pd.to_numeric(df[src], errors="coerce")
+    # Total sleep hours = light + slow-wave + REM (stored in milliseconds).
+    sleep_parts = [
+        "score_stage_summary_total_light_sleep_time_milli",
+        "score_stage_summary_total_slow_wave_sleep_time_milli",
+        "score_stage_summary_total_rem_sleep_time_milli",
+    ]
+    if all(c in df.columns for c in sleep_parts):
+        total_milli = sum(pd.to_numeric(df[c], errors="coerce") for c in sleep_parts)
+        out["sleep_hours"] = total_milli / 3.6e6
+    out["date"] = df["date"].values
+    return out.groupby("date").mean(numeric_only=True)
+
+
+def _food_daily(engine):
+    """Daily nutrient totals, scaled by serving quantity (mirrors the food plots)."""
+    if engine is None:
+        return pd.DataFrame()
+    try:
+        entries = pd.read_sql("SELECT * FROM food_entries", engine)
+        items = pd.read_sql("SELECT * FROM food_items", engine)
+    except Exception as e:
+        print(f"  Warning: could not read food tables: {e}")
+        return pd.DataFrame()
+    if entries.empty or items.empty:
+        return pd.DataFrame()
+
+    merged = entries.merge(items, left_on="food_item_id", right_on="id",
+                           suffixes=("", "_item"))
+    merged["date"] = pd.to_datetime(merged["consumed_at"]).dt.normalize()
+    qty = pd.to_numeric(merged["quantity"], errors="coerce").fillna(1)
+
+    # Source nutrient column -> metric key.
+    nutrient_map = {
+        "calories": "calories", "protein_g": "protein_g",
+        "carbohydrates_g": "carbs_g", "total_fat_g": "fat_g",
+        "saturated_fat_g": "sat_fat_g", "fiber_g": "fiber_g",
+        "sugar_g": "sugar_g", "sodium_mg": "sodium_mg", "iron_mg": "iron_mg",
+        "calcium_mg": "calcium_mg", "magnesium_mg": "magnesium_mg",
+        "potassium_mg": "potassium_mg",
+    }
+    out = pd.DataFrame({"date": merged["date"]})
+    for src, key in nutrient_map.items():
+        if src in merged.columns:
+            out[key] = pd.to_numeric(merged[src], errors="coerce") * qty
+    return out.groupby("date").sum(numeric_only=True)
+
+
+def _running_daily(engine):
+    """Mean running pace (min/mile) per day, plausible runs only."""
+    if engine is None:
+        return pd.DataFrame()
+    try:
+        act = pd.read_sql(
+            "SELECT activitydate, activitytype, elapsedtime, distance "
+            "FROM strava_activities", engine)
+    except Exception as e:
+        print(f"  Warning: could not read strava_activities: {e}")
+        return pd.DataFrame()
+    runs = act[act["activitytype"] == "Run"].copy()
+    if runs.empty:
+        return pd.DataFrame()
+    runs["date"] = pd.to_datetime(runs["activitydate"]).dt.normalize()
+    dist = pd.to_numeric(runs["distance"], errors="coerce")
+    runs["run_pace"] = (pd.to_numeric(runs["elapsedtime"], errors="coerce") / 60) / dist
+    runs = runs[(runs["run_pace"] >= 3.5) & (runs["run_pace"] <= 12)]
+    return runs.groupby("date")[["run_pace"]].mean()
+
+
+def _golf_daily(engine):
+    """Mean 18-hole score differential per day."""
+    if engine is None:
+        return pd.DataFrame()
+    try:
+        golf = pd.read_sql(
+            "SELECT played_at, differential, number_of_holes, adjusted_gross_score "
+            "FROM golf_scores", engine)
+    except Exception as e:
+        print(f"  Warning: could not read golf_scores: {e}")
+        return pd.DataFrame()
+    golf["differential"] = pd.to_numeric(golf["differential"], errors="coerce")
+    golf = golf[(golf["number_of_holes"] == 18)
+                & golf["differential"].notna()
+                & (pd.to_numeric(golf["adjusted_gross_score"], errors="coerce") > 50)]
+    if golf.empty:
+        return pd.DataFrame()
+    golf["date"] = pd.to_datetime(golf["played_at"]).dt.normalize()
+    return golf.groupby("date")[["differential"]].mean().rename(
+        columns={"differential": "golf_differential"})
+
+
+def build_daily_matrix(engine="auto", csv_path=CSV_PATH):
+    """Assemble one daily-indexed frame with a column per metric key.
+
+    engine='auto' builds a Postgres engine from .env; pass None to skip the
+    Postgres sources (CSV-only), or pass an existing SQLAlchemy engine.
+    """
+    if engine == "auto":
+        engine = _make_engine()
+
+    frames = [
+        _csv_daily(csv_path),
+        _food_daily(engine),
+        _running_daily(engine),
+        _golf_daily(engine),
+    ]
+    frames = [f for f in frames if not f.empty]
+    if not frames:
+        return pd.DataFrame()
+
+    matrix = pd.concat(frames, axis=1).sort_index()
+    # Keep only known metric columns, in registry order.
+    cols = [k for k in METRICS if k in matrix.columns]
+    matrix = matrix[cols]
+    matrix.index.name = "date"
+    return matrix
+
+
+# --------------------------------------------------------------------------
+# Delta core: yesterday vs trailing baseline
+# --------------------------------------------------------------------------
+def compute_deltas(matrix, as_of=None, baseline_days=BASELINE_DAYS, min_obs=MIN_OBS,
+                   min_active=MIN_ACTIVE):
+    """Rank each metric's as-of value against its own trailing baseline.
+
+    Returns a list of dicts (most deviant first). The baseline is the
+    `baseline_days` calendar days immediately *before* as_of; a metric is
+    only scored when as_of has a value and the baseline has >= min_obs
+    observations. z is the standardized deviation; better/worse is read off
+    the metric's good direction.
+    """
+    if matrix.empty:
+        return []
+
+    if as_of is None:
+        as_of = date.today() - timedelta(days=1)
+    as_of = pd.Timestamp(as_of).normalize()
+
+    window_start = as_of - pd.Timedelta(days=baseline_days)
+    baseline = matrix[(matrix.index >= window_start) & (matrix.index < as_of)]
+
+    if as_of not in matrix.index:
+        return []  # no data for the as-of day; nothing to compare
+    today_row = matrix.loc[as_of]
+    if isinstance(today_row, pd.DataFrame):  # dup dates -> average
+        today_row = today_row.mean()
+
+    results = []
+    for key in matrix.columns:
+        value = today_row.get(key, np.nan)
+        if pd.isna(value):
+            continue
+        hist = baseline[key].dropna()
+        if len(hist) < min_obs:
+            continue
+        # Skip categories that aren't really tracked, and those with no spread
+        # to judge against -- both would otherwise produce noise.
+        if int((hist != 0).sum()) < min_active:
+            continue
+        std = hist.std(ddof=0)
+        if not std or np.isnan(std):
+            continue
+
+        mean = hist.mean()
+        delta = value - mean
+        z = delta / std
+        pct = (delta / mean * 100) if mean else np.nan
+
+        label, domain, kind, direction, unit = METRICS[key]
+        if direction == 0:
+            sentiment = "neutral"
+        elif np.sign(delta) == 0:
+            sentiment = "neutral"
+        else:
+            sentiment = "better" if np.sign(delta) == direction else "worse"
+
+        results.append({
+            "key": key, "label": label, "domain": domain, "kind": kind,
+            "unit": unit, "direction": direction,
+            "value": float(value), "baseline_mean": float(mean),
+            "baseline_std": float(std), "delta": float(delta),
+            "pct": float(pct) if not np.isnan(pct) else None,
+            "z": float(z), "abs_z": float(abs(z)), "n_obs": int(len(hist)),
+            "sentiment": sentiment,
+        })
+
+    results.sort(key=lambda r: r["abs_z"], reverse=True)
+    return results
+
+
+WEEKDAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday",
+            "Saturday", "Sunday"]
+
+# How far back the weekday analysis looks, and the minimum same-weekday
+# observations needed before we trust a pattern.
+FOCUS_LOOKBACK_DAYS = 12 * 7
+FOCUS_MIN_OBS = 4
+FOCUS_MIN_ACTIVE = 5
+
+
+def weekday_focus(matrix, target_day=None, lookback_days=FOCUS_LOOKBACK_DAYS,
+                  min_obs=FOCUS_MIN_OBS, min_active=FOCUS_MIN_ACTIVE):
+    """What does this weekday historically slip on? -> what to focus on today.
+
+    Only directional *levers* (things you choose today, with a clear good
+    direction) are eligible. For each, we compare recent same-weekday history
+    against your other recent days. A positive `shortfall` means this weekday
+    tends to be worse on that lever -- you under-do a good thing or over-do a
+    bad one -- which is exactly what's worth focusing on. Ranked by the
+    standardized gap; most actionable first.
+    """
+    if matrix.empty:
+        return []
+
+    if target_day is None:
+        target_day = date.today()
+    target_dow = pd.Timestamp(target_day).weekday()
+
+    cutoff = pd.Timestamp(target_day).normalize() - pd.Timedelta(days=lookback_days)
+    recent = matrix[matrix.index >= cutoff]
+    if recent.empty:
+        return []
+
+    results = []
+    for key in matrix.columns:
+        label, domain, kind, direction, unit = METRICS[key]
+        if kind != "lever" or direction == 0:
+            continue
+
+        same = recent[recent.index.weekday == target_dow][key].dropna()
+        other = recent[recent.index.weekday != target_dow][key].dropna()
+        if len(same) < min_obs or len(other) < min_obs:
+            continue
+        # The metric must be genuinely tracked on other days; but the target
+        # weekday is allowed to be low/zero -- that low is the insight.
+        if int((other != 0).sum()) < min_active:
+            continue
+        other_std = other.std(ddof=0)
+        if not other_std or np.isnan(other_std):
+            continue
+
+        same_mean, other_mean = same.mean(), other.mean()
+        # gap: signed difference vs other days (+ = more on this weekday).
+        # shortfall: same gap read through good-direction (+ = worse for you).
+        gap = same_mean - other_mean
+        gap_z = gap / other_std
+        shortfall = -gap * direction
+        z = shortfall / other_std
+
+        results.append({
+            "key": key, "label": label, "domain": domain, "unit": unit,
+            "direction": direction, "weekday": WEEKDAYS[target_dow],
+            "weekday_mean": float(same_mean), "other_mean": float(other_mean),
+            "gap": float(gap), "gap_z": float(gap_z),
+            "shortfall": float(shortfall), "z": float(z), "abs_z": float(abs(z)),
+            "n_same": int(len(same)),
+            "needs_focus": bool(shortfall > 0),
+        })
+
+    # Most-slipping levers first; these are the focus candidates.
+    results.sort(key=lambda r: r["z"], reverse=True)
+    return results
+
+
+# How strong a weekday tilt must be before we call it a "more/less" pattern.
+PATTERN_Z = 0.5
+
+
+def weekday_patterns(matrix, target_day=None):
+    """Split the weekday signal into an actionable nudge and a neutral pattern.
+
+    - nutrition_focus: food levers this weekday tends to fall short on (low on a
+      good nutrient, or high on a bad one). These are worth acting on today.
+    - does_more / does_less: how this weekday's *activities* (time use) tilt vs
+      your other days, stated neutrally so you can choose to replicate or avoid.
+      Deliberately not prescriptive -- a low-coding Sunday is a fact, not a
+      to-do.
+    """
+    rows = weekday_focus(matrix, target_day=target_day)
+    weekday = rows[0]["weekday"] if rows else WEEKDAYS[
+        pd.Timestamp(target_day or date.today()).weekday()]
+
+    nutrition_focus = sorted(
+        [r for r in rows if r["domain"] == "food" and r["needs_focus"]],
+        key=lambda r: r["z"], reverse=True)
+    does_more = sorted(
+        [r for r in rows if r["domain"] == "time" and r["gap_z"] >= PATTERN_Z],
+        key=lambda r: r["gap_z"], reverse=True)
+    does_less = sorted(
+        [r for r in rows if r["domain"] == "time" and r["gap_z"] <= -PATTERN_Z],
+        key=lambda r: r["gap_z"])
+    return {
+        "weekday": weekday,
+        "nutrition_focus": nutrition_focus,
+        "does_more": does_more,
+        "does_less": does_less,
+    }
+
+
+def _fmt(v, unit):
+    s = f"{v:,.1f}" if abs(v) < 1000 else f"{v:,.0f}"
+    return f"{s}{unit}" if unit and unit != "%" else (f"{s}%" if unit == "%" else s)
+
+
+# --------------------------------------------------------------------------
+# Narration: structured stats -> short morning digest
+# --------------------------------------------------------------------------
+# Only surface retrospective movers at least this many SDs from baseline.
+NOTABLE_Z = 1.0
+CLAUDE_TIMEOUT_S = 90
+
+NARRATION_SYSTEM = (
+    "You write a short daily digest for the person whose own quantified-self "
+    "data this is. Use only the items and numbers provided; never invent any. "
+    "\n\n"
+    "Structure, two short paragraphs:\n"
+    "1. What changed yesterday versus their typical last four weeks.\n"
+    "2. Today: first, the nutrition worth hitting today (the listed nutrition "
+    "focus items). Then, neutrally, how this weekday usually tends to go for "
+    "their activities (what they do more and less of), stated as an observation "
+    "they can act on or ignore. Do not tell them to work, block time, or be "
+    "productive; just report the pattern.\n\n"
+    "Voice: plain, everyday words and short sentences, like a knowledgeable "
+    "friend texting you. Second person. Direct and honest, not a cheerleader. "
+    "Hard rules: no em dashes, no semicolons, no emojis, no markdown, no bullet "
+    "lists, no preamble. Avoid dramatic phrasing (no 'swung hard', 'ran hot', "
+    "'on the upside'). Just say what happened. Under 120 words total."
+)
+
+
+def summarize_day(matrix, as_of=None, today=None):
+    """Bundle the retrospective deltas + prospective focus into one payload."""
+    if as_of is None:
+        as_of = date.today() - timedelta(days=1)
+    if today is None:
+        today = date.today()
+
+    deltas = compute_deltas(matrix, as_of=as_of)
+    notable = [d for d in deltas if d["abs_z"] >= NOTABLE_Z]
+    patterns = weekday_patterns(matrix, target_day=today)
+
+    return {
+        "as_of": str(as_of),
+        "today_weekday": WEEKDAYS[pd.Timestamp(today).weekday()],
+        "movers": notable,
+        "nutrition_focus": patterns["nutrition_focus"],
+        "does_more": patterns["does_more"],
+        "does_less": patterns["does_less"],
+    }
+
+
+def _payload_to_prompt(payload):
+    """Render the structured payload into a compact prompt for Claude."""
+    wd = payload["today_weekday"]
+    lines = [f"Yesterday: {payload['as_of']}",
+             f"Today is: {wd}", "",
+             "What changed yesterday vs the trailing 4 weeks "
+             "(value | typical | direction):"]
+    if payload["movers"]:
+        for d in payload["movers"]:
+            arrow = "up" if d["delta"] > 0 else "down"
+            lines.append(
+                f"- {d['label']}: {_fmt(d['value'], d['unit'])} "
+                f"(typical {_fmt(d['baseline_mean'], d['unit'])}), "
+                f"{arrow}, {d['sentiment']}")
+    else:
+        lines.append("- nothing notably different from typical")
+
+    lines += ["", f"Nutrition worth hitting today ({wd}s tend to fall short here):"]
+    if payload["nutrition_focus"]:
+        for f in payload["nutrition_focus"][:5]:
+            short = "tends low" if f["direction"] > 0 else "tends high"
+            lines.append(
+                f"- {f['label']}: {short} ({_fmt(f['weekday_mean'], f['unit'])} "
+                f"vs {_fmt(f['other_mean'], f['unit'])} on other days)")
+    else:
+        lines.append("- nothing specific")
+
+    lines += ["", f"How your {wd}s usually tilt for activities (neutral, just a "
+              "pattern they can replicate or avoid):"]
+    if payload["does_more"]:
+        for f in payload["does_more"][:3]:
+            lines.append(
+                f"- more {f['label']}: {_fmt(f['weekday_mean'], f['unit'])} "
+                f"vs {_fmt(f['other_mean'], f['unit'])} other days")
+    if payload["does_less"]:
+        for f in payload["does_less"][:3]:
+            lines.append(
+                f"- less {f['label']}: {_fmt(f['weekday_mean'], f['unit'])} "
+                f"vs {_fmt(f['other_mean'], f['unit'])} other days")
+    if not payload["does_more"] and not payload["does_less"]:
+        lines.append("- no clear activity tilt")
+    return "\n".join(lines)
+
+
+def _find_claude():
+    """Locate the claude binary without relying on PATH (LaunchAgents are bare)."""
+    found = shutil.which("claude")
+    if found:
+        return found
+    for cand in ("~/.local/bin/claude", "/usr/local/bin/claude",
+                 "/opt/homebrew/bin/claude", "~/.claude/local/claude"):
+        p = os.path.expanduser(cand)
+        if os.path.exists(p):
+            return p
+    return None
+
+
+def _claude_narrate(prompt, timeout=CLAUDE_TIMEOUT_S):
+    """Narrate via the Claude Code CLI using subscription OAuth. None on failure.
+
+    Uses plain `-p` (not `--bare`, which ignores CLAUDE_CODE_OAUTH_TOKEN) and
+    disables tools so it's a pure text completion. Runs from the home dir so it
+    doesn't load this repo's project MCP servers / skills. The OAuth token is
+    inherited from the environment (load_dotenv puts CLAUDE_CODE_OAUTH_TOKEN
+    from .env into os.environ), so no secret needs to live in the plist.
+    """
+    claude_bin = _find_claude()
+    if not claude_bin:
+        return None
+    try:
+        proc = subprocess.run(
+            [claude_bin, "-p", "--output-format", "text",
+             "--append-system-prompt", NARRATION_SYSTEM, "--allowedTools", ""],
+            input=prompt, capture_output=True, text=True, timeout=timeout,
+            cwd=os.path.expanduser("~"),
+        )
+    except Exception as e:
+        print(f"  Claude narration failed ({e}); using template.")
+        return None
+    if proc.returncode != 0:
+        print(f"  Claude narration exited {proc.returncode}; using template.")
+        return None
+    return proc.stdout.strip() or None
+
+
+def _template_narrative(payload):
+    """Deterministic fallback prose when Claude is unavailable.
+
+    Kept in the same plain register as the Claude prompt: no em dashes, no
+    semicolons, short sentences.
+    """
+    wd = payload["today_weekday"]
+    movers = payload["movers"]
+
+    if movers:
+        bits = []
+        for d in movers[:4]:
+            arrow = "up" if d["delta"] > 0 else "down"
+            tag = "" if d["sentiment"] == "neutral" else f" ({d['sentiment']})"
+            bits.append(f"{d['label'].lower()} was {arrow} at "
+                        f"{_fmt(d['value'], d['unit'])} from a typical "
+                        f"{_fmt(d['baseline_mean'], d['unit'])}{tag}")
+        para1 = "Yesterday vs your last four weeks: " + ", ".join(bits) + "."
+    else:
+        para1 = "Yesterday looked close to your usual four-week pattern."
+
+    sentences = []
+    focus = payload["nutrition_focus"]
+    if focus:
+        items = []
+        for f in focus[:3]:
+            verb = "more" if f["direction"] > 0 else "less"
+            items.append(f"{verb} {f['label'].lower()}")
+        sentences.append(f"On nutrition, {wd}s are a day to aim for "
+                         + ", ".join(items) + ".")
+
+    more = [f["label"].lower() for f in payload["does_more"][:3]]
+    less = [f["label"].lower() for f in payload["does_less"][:3]]
+    if more:
+        sentences.append(f"You usually do more {', '.join(more)} on {wd}s.")
+    if less:
+        sentences.append(f"You usually do less {', '.join(less)}.")
+    if not sentences:
+        sentences.append(f"No clear {wd} pattern stands out.")
+    para2 = " ".join(sentences)
+    return f"{para1}\n\n{para2}"
+
+
+def narrate(matrix, as_of=None, today=None, use_claude=True):
+    """Produce the morning digest text (Claude when available, else template)."""
+    payload = summarize_day(matrix, as_of=as_of, today=today)
+    if use_claude:
+        text = _claude_narrate(_payload_to_prompt(payload))
+        if text:
+            return text, payload, "claude"
+    return _template_narrative(payload), payload, "template"
+
+
+def main():
+    matrix = build_daily_matrix()
+    if matrix.empty:
+        print("No data available to build the daily matrix.")
+        return
+
+    as_of = date.today() - timedelta(days=1)
+    deltas = compute_deltas(matrix, as_of=as_of)
+
+    print(f"\nDaily change-digest for {as_of} "
+          f"(vs trailing {BASELINE_DAYS} days)")
+    print(f"Matrix: {matrix.shape[0]} days x {matrix.shape[1]} metrics, "
+          f"through {matrix.index.max().date()}")
+    if not deltas:
+        print("  No metrics had data for the as-of day with a usable baseline.")
+        return
+
+    print(f"\n{'metric':<22}{'kind':<9}{'value':>12}{'baseline':>12}"
+          f"{'z':>7}  sentiment")
+    print("-" * 78)
+    for d in deltas:
+        print(f"{d['label']:<22}{d['kind']:<9}"
+              f"{_fmt(d['value'], d['unit']):>12}"
+              f"{_fmt(d['baseline_mean'], d['unit']):>12}"
+              f"{d['z']:>+7.1f}  {d['sentiment']}")
+
+    # Prospective: today's weekday signal, split into nutrition focus + pattern.
+    today = date.today()
+    wd = WEEKDAYS[today.weekday()]
+    pat = weekday_patterns(matrix, target_day=today)
+
+    def _row(tag, f):
+        print(f"{tag + ' ' + f['label']:<26}"
+              f"{_fmt(f['weekday_mean'], f['unit']):>12}"
+              f"{_fmt(f['other_mean'], f['unit']):>12}"
+              f"{f.get('z', f.get('gap_z')):>+8.1f}")
+
+    print(f"\n{wd}: nutrition worth hitting today:")
+    if pat["nutrition_focus"]:
+        for f in pat["nutrition_focus"][:5]:
+            _row("low on" if f["direction"] > 0 else "high on", f)
+    else:
+        print("  nothing specific")
+
+    print(f"\n{wd}: how your activities usually tilt (neutral):")
+    if pat["does_more"] or pat["does_less"]:
+        for f in pat["does_more"][:3]:
+            _row("more", f)
+        for f in pat["does_less"][:3]:
+            _row("less", f)
+    else:
+        print("  no clear tilt")
+
+    # Narrative digest (Claude via subscription OAuth, template fallback)
+    use_claude = "--no-claude" not in sys.argv
+    text, _, source = narrate(matrix, as_of=as_of, today=today, use_claude=use_claude)
+    print(f"\n=== Morning digest ({source}) ===\n")
+    print(text)
+
+    if "--push" in sys.argv:
+        import ntfy
+        ok = ntfy.push(text, title=f"Daily digest, {wd}")
+        print(f"\nPush sent: {ok}")
+
+
+if __name__ == "__main__":
+    main()

--- a/Scripts/generate_food_plots.py
+++ b/Scripts/generate_food_plots.py
@@ -85,9 +85,10 @@ def save_plot(fig, filename):
 
 
 def _format_date_axis(ax):
-    """Set x-axis to show one tick per day with clean formatting."""
-    ax.xaxis.set_major_locator(mdates.DayLocator())
-    ax.xaxis.set_major_formatter(mdates.DateFormatter('%b %d'))
+    """Set x-axis to a readable number of date ticks regardless of range."""
+    locator = mdates.AutoDateLocator(minticks=4, maxticks=10)
+    ax.xaxis.set_major_locator(locator)
+    ax.xaxis.set_major_formatter(mdates.ConciseDateFormatter(locator, show_offset=False))
 
 
 def generate_all():

--- a/Scripts/regime_clustering.py
+++ b/Scripts/regime_clustering.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python
+"""Tier 2 clustering: labeled day-regimes over the recent multi-domain dense window.
+
+The long-history view in app.py is an embedding/recurrence exploration on
+always-present features (time + Whoop). This module is the complementary second
+tier: over the recent window where food is logged densely, it assigns each day a
+real regime label and shows how regimes move over time.
+
+Design choices (see the daily-change-digest work):
+  - Window is auto-detected: the earliest start from which food coverage stays
+    dense through today, so it adapts as more data accrues.
+  - Food (dense in the window) participates directly. Event-based pace/golf stay
+    sparse even recently, so they enter only as honest binary indicators
+    (ran / golfed) -- never a faked continuous 0.
+  - Days without food logged are dropped from the window, so every clustered day
+    genuinely has the multi-domain picture.
+"""
+
+import base64
+from io import BytesIO
+
+import numpy as np
+import pandas as pd
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+from sklearn.preprocessing import StandardScaler
+from sklearn.decomposition import PCA
+from sklearn.cluster import AgglomerativeClustering
+from sklearn.metrics import silhouette_score
+
+from clustering_features import clustering_feature_columns
+
+RANDOM_STATE = 2225
+FOOD_SIGNAL_COL = 'calories'   # presence of this == "food logged that day"
+
+
+# --------------------------------------------------------------------------
+# 1. Auto-detect the recent dense window
+# --------------------------------------------------------------------------
+def detect_dense_window(model_df, food_col=FOOD_SIGNAL_COL,
+                        min_coverage=0.5, min_days=21):
+    """Earliest start date from which food coverage stays dense through the end.
+
+    Walks candidate start dates (days food was logged) from earliest to latest;
+    coverage of [start, end] only rises as start advances, so the first start
+    whose window clears min_coverage is the widest dense window. Falls back to
+    the first logged day if nothing clears the bar.
+
+    Returns (start_date, windowed_df) where windowed_df is model_df restricted to
+    [start, end]. Returns (None, empty) if the food column is absent/empty.
+    """
+    if food_col not in model_df.columns:
+        return None, model_df.iloc[0:0]
+
+    df = model_df.copy()
+    df['_date'] = pd.to_datetime(df['date_column']).dt.normalize()
+    df = df.sort_values('_date')
+
+    logged = df[df[food_col].notna()]
+    if logged.empty:
+        return None, model_df.iloc[0:0]
+
+    end = df['_date'].max()
+    logged_dates = logged['_date'].drop_duplicates().sort_values()
+
+    chosen = logged_dates.iloc[0]  # fallback: first logged day
+    for start in logged_dates:
+        span_days = (end - start).days + 1
+        if span_days < min_days:
+            break  # remaining starts are even shorter
+        window = df[(df['_date'] >= start) & (df['_date'] <= end)]
+        covered = window[food_col].notna().sum()
+        if covered / span_days >= min_coverage:
+            chosen = start
+            break
+
+    windowed = df[df['_date'] >= chosen].drop(columns='_date')
+    return chosen, windowed
+
+
+# --------------------------------------------------------------------------
+# 2. Build the food-inclusive regime feature matrix
+# --------------------------------------------------------------------------
+def build_regime_matrix(windowed_df, food_col=FOOD_SIGNAL_COL,
+                        max_col_missing=0.3):
+    """Complete-case multi-domain feature matrix for the window (no faked fills).
+
+    Unlike the long-history projection, Tier 2 does NOT fillna(0): a missing
+    Whoop score means "not worn", not zero, and faking it creates a bogus
+    "low-Whoop" regime. So we keep values as-is, drop columns that are missing on
+    too many window days, then keep only complete-case days. Time-allocation 0s
+    are genuine ("didn't do it") and stay. Event-based pace/golf enter only as
+    honest binary `ran` / `golfed` indicators.
+    """
+    if windowed_df.empty or food_col not in windowed_df.columns:
+        return pd.DataFrame()
+
+    df = windowed_df[windowed_df[food_col].notna()].copy()
+    if df.empty:
+        return pd.DataFrame()
+
+    dates = pd.to_datetime(df['date_column']).dt.normalize()
+    exclude = clustering_feature_columns(df)
+    numeric = df.select_dtypes(include=['float64', 'int64']).columns
+    feats = df[numeric].drop(columns=exclude, errors='ignore').copy()
+    feats.index = dates.values
+
+    # Honest event indicators (always defined: 1 if it happened, else 0).
+    if 'run_pace' in df.columns:
+        feats['ran'] = df['run_pace'].notna().astype(int).values
+    if 'golf_differential' in df.columns:
+        feats['golfed'] = df['golf_differential'].notna().astype(int).values
+
+    # Time/activity/food zeros are genuine ("didn't do it"), so a missing value
+    # there means 0. A missing Whoop score (score_*) means "not worn", which we
+    # will not fake -- those days drop out via the complete-case step below.
+    score_cols = [c for c in feats.columns if c.startswith('score_')]
+    non_score = [c for c in feats.columns if c not in score_cols]
+    feats[non_score] = feats[non_score].fillna(0)
+
+    # Drop near-empty / all-zero / constant columns, then keep complete-case days
+    # (which removes only the days the Whoop was not worn).
+    feats = feats.loc[:, feats.notna().mean() >= (1 - max_col_missing)]
+    feats = feats.loc[:, (feats.fillna(0) != 0).any(axis=0)]
+    feats = feats.dropna()
+    feats = feats.loc[:, feats.std(ddof=0) > 1e-9]
+    feats.index.name = 'date'
+    return feats
+
+
+# --------------------------------------------------------------------------
+# 3. Assign regimes
+# --------------------------------------------------------------------------
+def assign_regimes(features, k_range=range(2, 6), random_state=RANDOM_STATE):
+    """Scale, pick k by silhouette, and assign an agglomerative regime per day.
+
+    Returns dict: labels (Series indexed by date), k, scaled (DataFrame),
+    embedding2d (ndarray n x 2 via PCA for viz), silhouettes (dict k->score).
+    Returns None if there are too few days to cluster.
+    """
+    if features.empty or len(features) < max(6, min(k_range) + 1):
+        return None
+
+    # PCA's SVD on a rank-deficient matrix (more features than days) emits benign
+    # divide/overflow RuntimeWarnings in numpy's matmul; the results are sound.
+    # Suppress just the floating-point warnings around the numeric work.
+    with np.errstate(divide='ignore', over='ignore', invalid='ignore'):
+        scaler = StandardScaler()
+        X = scaler.fit_transform(features.values)
+        # A near-constant column gets a tiny std, so its rare outlier scales to a
+        # huge z. Clip z-scores to a sane range and scrub any non-finite values.
+        X = np.clip(np.nan_to_num(X, nan=0.0, posinf=0.0, neginf=0.0), -8, 8)
+
+        # Reduce before clustering: with more features than days the covariance
+        # is singular (noisy distances). Project to a handful of PCs capping at
+        # n_samples-1, which also denoises the regime structure.
+        n_samples, n_features = X.shape
+        n_pcs = max(2, min(10, n_features, n_samples - 1))
+        pca = PCA(n_components=n_pcs, random_state=random_state)
+        X_red = pca.fit_transform(X)
+
+        # Pick k by best silhouette, but reject solutions with a singleton regime
+        # (a one-day "regime" is noise, not a pattern). Cap k for small windows.
+        sils = {}
+        max_k = min(max(k_range), max(2, n_samples // 6))
+        best_k, best_score, best_labels = None, -1.0, None
+        for k in k_range:
+            if k > max_k or k >= n_samples:
+                continue
+            labels = AgglomerativeClustering(n_clusters=k).fit_predict(X_red)
+            _, counts = np.unique(labels, return_counts=True)
+            if counts.min() < 2:
+                continue  # no singleton regimes
+            score = silhouette_score(X_red, labels)
+            sils[k] = float(score)
+            if score > best_score:
+                best_k, best_score, best_labels = k, score, labels
+
+        if best_labels is None:  # fall back to k=2 if nothing else qualified
+            best_labels = AgglomerativeClustering(n_clusters=2).fit_predict(X_red)
+            best_k, best_score = 2, float(silhouette_score(X_red, best_labels))
+
+    # Relabel regimes by first appearance so "Regime 1" is the earliest one.
+    order = pd.unique(best_labels)
+    remap = {old: new for new, old in enumerate(order)}
+    relabeled = np.array([remap[v] for v in best_labels])
+
+    embedding2d = X_red[:, :2] if X_red.shape[1] >= 2 \
+        else np.column_stack([X_red[:, 0], np.zeros(len(X_red))])
+
+    return {
+        'labels': pd.Series(relabeled, index=features.index, name='regime'),
+        'k': best_k,
+        'silhouette': best_score,
+        'silhouettes': sils,
+        'scaled': pd.DataFrame(X, index=features.index, columns=features.columns),
+        'embedding2d': embedding2d,
+    }
+
+
+# --------------------------------------------------------------------------
+# 4. Characterize each regime
+# --------------------------------------------------------------------------
+def profile_regimes(features, labels, top_n=5):
+    """Per regime: size, date range, and the features that most define it.
+
+    Distinctiveness = z-scored regime mean vs the overall mean (so it reads as
+    'this regime runs high on X, low on Y' relative to a typical window day).
+    """
+    z = (features - features.mean()) / features.std(ddof=0).replace(0, np.nan)
+    rows = []
+    for regime in sorted(labels.unique()):
+        idx = labels[labels == regime].index
+        member_z = z.loc[idx].mean().dropna().sort_values()
+        # Show each regime's most distinctive features by direction, always, so
+        # even the near-baseline cluster gets a readable profile.
+        highs = member_z[member_z > 0].tail(top_n)[::-1]
+        lows = member_z[member_z < 0].head(top_n)
+        rows.append({
+            'Regime': f'Regime {regime + 1}',
+            'Days': int(len(idx)),
+            'From': str(min(idx).date()),
+            'To': str(max(idx).date()),
+            'Runs high on': ', '.join(highs.index) or '(near typical)',
+            'Runs low on': ', '.join(lows.index) or '(near typical)',
+        })
+    return pd.DataFrame(rows)
+
+
+# --------------------------------------------------------------------------
+# 5. Transitions over time
+# --------------------------------------------------------------------------
+def summarize_transitions(labels):
+    """Counts, current regime, and the run lengths of each regime stint."""
+    seq = labels.sort_index()
+    changes = (seq.values[1:] != seq.values[:-1]).sum()
+    # Length of the current (most recent) uninterrupted regime stint.
+    cur = seq.iloc[-1]
+    run = 0
+    for v in seq.values[::-1]:
+        if v == cur:
+            run += 1
+        else:
+            break
+    return {
+        'n_days': int(len(seq)),
+        'n_regimes': int(seq.nunique()),
+        'n_transitions': int(changes),
+        'current_regime': f'Regime {int(cur) + 1}',
+        'current_run_days': int(run),
+    }
+
+
+# --------------------------------------------------------------------------
+# 6. Plots
+# --------------------------------------------------------------------------
+def _b64(fig):
+    buf = BytesIO()
+    fig.savefig(buf, format='png', bbox_inches='tight', dpi=100)
+    buf.seek(0)
+    out = base64.b64encode(buf.read()).decode('utf-8')
+    plt.close(fig)
+    return out
+
+
+def plot_regime_timeline(labels):
+    """Step plot of regime over time (which regime each day falls in)."""
+    seq = labels.sort_index()
+    k = int(seq.max()) + 1
+    cmap = plt.get_cmap('tab10')
+
+    fig, ax = plt.subplots(figsize=(16, 4))
+    ax.scatter(seq.index, seq.values + 1, c=[cmap(v) for v in seq.values],
+               s=60, zorder=3)
+    ax.step(seq.index, seq.values + 1, where='post', color='#9ca3af',
+            linewidth=1, alpha=0.6, zorder=1)
+    ax.set_yticks(range(1, k + 1))
+    ax.set_yticklabels([f'Regime {i}' for i in range(1, k + 1)])
+    ax.set_xlabel('Date', fontsize=14, labelpad=8)
+    ax.set_title('Daily regime over the recent dense window', fontsize=16,
+                 fontweight='bold', pad=12)
+    ax.tick_params(labelsize=11)
+    for label in ax.get_xticklabels():
+        label.set_rotation(45)
+        label.set_ha('right')
+    fig.tight_layout()
+    return _b64(fig)
+
+
+def plot_regime_embedding(embedding2d, labels):
+    """2D PCA scatter of the window's days, colored by regime."""
+    seq = labels.sort_index()
+    emb = pd.DataFrame(embedding2d, index=labels.index, columns=['x', 'y']).loc[seq.index]
+    cmap = plt.get_cmap('tab10')
+
+    fig, ax = plt.subplots(figsize=(8, 7))
+    for regime in sorted(seq.unique()):
+        m = seq == regime
+        ax.scatter(emb['x'][m.values], emb['y'][m.values], s=70, alpha=0.8,
+                   color=cmap(regime), label=f'Regime {regime + 1}',
+                   edgecolors='white', linewidth=0.5)
+    ax.set_xlabel('PC 1', fontsize=14, labelpad=8)
+    ax.set_ylabel('PC 2', fontsize=14, labelpad=8)
+    ax.set_title('Recent days in feature space, by regime', fontsize=16,
+                 fontweight='bold', pad=12)
+    ax.legend(frameon=False, fontsize=11, loc='upper left',
+              bbox_to_anchor=(1.02, 1.0))
+    ax.tick_params(labelsize=11)
+    fig.tight_layout()
+    return _b64(fig)
+
+
+# --------------------------------------------------------------------------
+# Orchestration
+# --------------------------------------------------------------------------
+def build_recent_regimes(model_df):
+    """Full Tier 2 pipeline. Returns a dict of artifacts, or {'ok': False, ...}."""
+    start, windowed = detect_dense_window(model_df)
+    if windowed.empty:
+        return {'ok': False, 'reason': 'no dense food-logged window yet'}
+
+    features = build_regime_matrix(windowed)
+    result = assign_regimes(features)
+    if result is None:
+        return {'ok': False, 'reason': f'too few days to cluster ({len(features)})'}
+
+    labels = result['labels']
+    return {
+        'ok': True,
+        'window_start': str(pd.Timestamp(start).date()),
+        'window_end': str(labels.index.max().date()),
+        'n_features': features.shape[1],
+        'k': result['k'],
+        'silhouette': round(result['silhouette'], 3),
+        'profiles': profile_regimes(features, labels),
+        'transitions': summarize_transitions(labels),
+        'timeline_b64': plot_regime_timeline(labels),
+        'embedding_b64': plot_regime_embedding(result['embedding2d'], labels),
+        'labels': labels,
+    }
+
+
+def _load_model_df():
+    """Standalone: read the modeling table (fresh) or fall back to the CSV."""
+    import os
+    from pathlib import Path
+    from dotenv import load_dotenv
+    from sqlalchemy import create_engine
+    load_dotenv()
+    try:
+        url = (f"postgresql://{os.getenv('DB_USER')}:{os.getenv('DB_PASSWORD')}@"
+               f"{os.getenv('DB_HOST')}:{os.getenv('DB_PORT')}/{os.getenv('DB_NAME')}")
+        return pd.read_sql("SELECT * FROM modeling_ready_data", create_engine(url))
+    except Exception as e:
+        print(f"  DB read failed ({e}); using modeling_data.csv")
+        csv = Path(__file__).resolve().parent.parent / 'Data' / 'modeling_data.csv'
+        return pd.read_csv(csv)
+
+
+def main():
+    out = build_recent_regimes(_load_model_df())
+    if not out['ok']:
+        print(f"Tier 2 regimes unavailable: {out['reason']}")
+        return
+    print(f"Recent dense window: {out['window_start']} -> {out['window_end']}")
+    print(f"{out['n_features']} features, k={out['k']} "
+          f"(silhouette {out['silhouette']})")
+    t = out['transitions']
+    print(f"{t['n_days']} days, {t['n_regimes']} regimes, "
+          f"{t['n_transitions']} transitions. Currently {t['current_regime']} "
+          f"for {t['current_run_days']} day(s).\n")
+    with pd.option_context('display.max_colwidth', 60, 'display.width', 140):
+        print(out['profiles'].to_string(index=False))
+
+
+if __name__ == '__main__':
+    main()

--- a/Scripts/run_all.py
+++ b/Scripts/run_all.py
@@ -7,6 +7,11 @@ import re
 import os
 from pathlib import Path
 
+# Headless/scheduled mode: skip the blocking Dash dashboard and the interactive
+# Whoop browser-OAuth fallback, and finish by pushing the daily digest. Used by
+# the morning LaunchAgent (run_all.py --no-dashboard).
+HEADLESS = '--no-dashboard' in sys.argv or '--headless' in sys.argv
+
 def run_script(script_path):
     """Function to run a script."""
     subprocess.run([sys.executable, script_path], check=True)
@@ -31,6 +36,12 @@ def get_fresh_whoop_token():
         print("Silent refresh timed out, falling back to browser flow...")
     except Exception as e:
         print(f"Silent refresh error: {e}, falling back to browser flow...")
+
+    # In a headless/scheduled run we cannot complete a browser OAuth flow, so
+    # skip it rather than hang. Whoop is simply not refreshed this run.
+    if HEADLESS:
+        print("Headless run: skipping browser OAuth fallback for Whoop.")
+        return None
 
     # Step 2: Fall back to full browser OAuth flow
     try:
@@ -138,15 +149,19 @@ except subprocess.CalledProcessError as e:
 except Exception as e:
     print(f"Error generating food plots: {e}")
 
-# Update academic data from CV and manuscript folders
-print("\n\nUpdating academic data from CV and manuscripts...")
-try:
-    run_script('update_academic_data.py')
-    print("Academic data updated")
-except subprocess.CalledProcessError as e:
-    print(f"Error updating academic data: {e}")
-except Exception as e:
-    print(f"Error updating academic data: {e}")
+# Update academic data from CV and manuscript folders. This script prompts for
+# interactive input, so it cannot run in a headless/scheduled context.
+if HEADLESS:
+    print("\n\nHeadless run: skipping interactive academic data update.")
+else:
+    print("\n\nUpdating academic data from CV and manuscripts...")
+    try:
+        run_script('update_academic_data.py')
+        print("Academic data updated")
+    except subprocess.CalledProcessError as e:
+        print(f"Error updating academic data: {e}")
+    except Exception as e:
+        print(f"Error updating academic data: {e}")
 
 # Prep the data for unsupervised learning
 print("\n\nPrepping data for unsupervised learning...")
@@ -184,6 +199,19 @@ try:
 except Exception as e:
     print(f"Error during Launch Agent health check: {e}")
 
-# Run the dashboard script
-print("\n\nRunning dashboard creation...")
-run_script('app.py')
+if HEADLESS:
+    # Cron/LaunchAgent path: the clustering data + CSV were just refreshed by
+    # unsupervised_ml_data_prep.py above, so build and push the daily digest
+    # instead of launching the blocking Dash dashboard.
+    print("\n\nBuilding and pushing the daily digest...")
+    try:
+        subprocess.run([sys.executable, 'daily_digest.py', '--push'], check=True)
+        print("Daily digest pushed")
+    except subprocess.CalledProcessError as e:
+        print(f"Error running daily digest: {e}")
+    except Exception as e:
+        print(f"An unexpected error occurred building the daily digest: {e}")
+else:
+    # Run the dashboard script
+    print("\n\nRunning dashboard creation...")
+    run_script('app.py')

--- a/Scripts/unsupervised_ml_data_prep.py
+++ b/Scripts/unsupervised_ml_data_prep.py
@@ -212,15 +212,32 @@ all_data = all_data.sort_values(by=['Year', 'DayOfYear'])
 model_df = all_data.copy()
 model_df['date_column'] = model_df['date_column'].astype(str)
 
+# Food, running pace, and golf differential: reuse the daily aggregations from
+# the digest module so there is a single source of truth for how each domain is
+# rolled up to a per-day value. Each returns a date-indexed frame; we move the
+# date back to a column so it slots into the same merge pattern below. Guarded
+# so an empty/unavailable source simply adds nothing.
+import daily_digest
+
+_extra_daily = {
+    'food': daily_digest._food_daily(engine),
+    'run_pace': daily_digest._running_daily(engine),
+    'golf': daily_digest._golf_daily(engine),
+}
+
 # Define date columns for different dataframes
 date_cols = {
-    'baseball': ('date', baseball), 
+    'baseball': ('date', baseball),
     'cycle_collection': ('created_at', cycle_collection),
     'recoveries': ('created_at', recoveries),
     'sleep_collection': ('created_at', sleep_collection),
     'workouts': ('created_at', workouts),
     'phys_act': ('date', wide_phys_act)
 }
+
+for _name, _frame in _extra_daily.items():
+    if _frame is not None and not _frame.empty:
+        date_cols[_name] = ('date', _frame.reset_index())
 
 # Process each dataframe: convert to datetime, remove time, and set index
 cleaned_dfs = pd.DataFrame()
@@ -280,3 +297,12 @@ model_df = model_df.drop_duplicates(subset=['date_column'], keep="first").reset_
 # Push to Database
 model_df.to_sql('modeling_ready_data', engine, if_exists='replace', index=False)
 model_df.to_csv('../Data/modeling_data.csv', index=False)
+
+# Also write the numeric clustering projection here so it can be refreshed on a
+# schedule without launching the (blocking) Dash app. Uses the same shared
+# projection app.py applies (clustering_features.write_clustering_csv). The
+# daily digest (daily_digest.py) reads this file.
+from clustering_features import write_clustering_csv
+write_clustering_csv(
+    model_df,
+    os.path.join(os.path.dirname(__file__), '..', 'Data', 'df_numeric_for_clustering.csv'))


### PR DESCRIPTION
## Summary

Three threads of work from this session.

### Plot fixes
- Golf and all food-intake charts: overlapping x-axis date ticks fixed via `AutoDateLocator` + `ConciseDateFormatter` (was one tick per day).
- Running-pace boxplot: legend moved to upper-left in 3 columns; switched to a distinct per-year palette (`husl`) since 13 years exceeded `tab10`.

### Daily change-digest (`Scripts/daily_digest.py`)
A morning digest: "here's what yesterday looked like vs the last four weeks, and given today's weekday, here's what to focus on."
- Unified daily matrix from four sources (time + Whoop from the clustering CSV; food, running pace, golf live from Postgres), each metric tagged **lever vs outcome** with a good-direction.
- **Retrospective:** yesterday vs trailing-28-day baseline, ranked by z-score.
- **Prospective:** today's weekday vs other days — actionable nutrition focus kept separate from a neutral more/less activity pattern.
- Nonzero-coverage gate so untracked/sparse categories are excluded rather than read as "dropped to 0".
- Narration via the **Claude Code subscription OAuth token** (no API key), with a deterministic template fallback. Pushes via `ntfy`.

### Daily refresh + clustering enrichment
- `unsupervised_ml_data_prep.py` now merges **food, running pace, and golf** into `modeling_ready_data` and writes `df_numeric_for_clustering.csv` itself.
- `run_all.py --no-dashboard`: headless morning path that pulls sources, preps, and pushes the digest, skipping the blocking Dash app, the Whoop browser-OAuth fallback, and the interactive academic-data step.
- LaunchAgent `com.davidjcox.daily-digest` runs it each morning (6 AM).
- `run_pace`/`golf_differential` excluded from the clustering matrix (0 is meaningless for a rate/score) and left as honest NaN in `modeling_data.csv`.
- Shared projection factored into `Scripts/clustering_features.py`, used by both `app.py` and the prep script.

## Testing
- Food/golf plots regenerated and visually verified (ticks readable, no overlap).
- Digest validated end-to-end against real data; Claude narration confirmed (~10s, no API billing).
- LaunchAgent installed and validated — the `RunAtLoad` run pulled sources, refreshed the clustering data, and pushed the digest.
- Refactor verified to produce an identical clustering column set.

## Follow-ups (not in this PR)
- Temporal/regime clustering and a goals + cross-domain correlation layer.
- Revisit how food (short history) should enter clustering — likely a recent-dense-window model rather than `fillna(0)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)